### PR TITLE
Add weight and dimensions to products

### DIFF
--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -120,6 +120,30 @@ class ProductResource extends Resource
                         'default' => 2,
                         'lg' => 1
                     ]),
+                TextInput::make('weight')
+                    ->numeric()
+                    ->columnSpan([
+                        'default' => 2,
+                        'lg' => 1
+                    ]),
+                TextInput::make('length')
+                    ->numeric()
+                    ->columnSpan([
+                        'default' => 2,
+                        'lg' => 1
+                    ]),
+                TextInput::make('width')
+                    ->numeric()
+                    ->columnSpan([
+                        'default' => 2,
+                        'lg' => 1
+                    ]),
+                TextInput::make('height')
+                    ->numeric()
+                    ->columnSpan([
+                        'default' => 2,
+                        'lg' => 1
+                    ]),
                 Select::make('status')
                     ->options(ProductStatusEnum::labels())
                     ->default(ProductStatusEnum::Draft->value)

--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -121,24 +121,28 @@ class ProductResource extends Resource
                         'lg' => 1
                     ]),
                 TextInput::make('weight')
+                    ->label('Weight (kg)')
                     ->numeric()
                     ->columnSpan([
                         'default' => 2,
                         'lg' => 1
                     ]),
                 TextInput::make('length')
+                    ->label('Length (cm)')
                     ->numeric()
                     ->columnSpan([
                         'default' => 2,
                         'lg' => 1
                     ]),
                 TextInput::make('width')
+                    ->label('Width (cm)')
                     ->numeric()
                     ->columnSpan([
                         'default' => 2,
                         'lg' => 1
                     ]),
                 TextInput::make('height')
+                    ->label('Height (cm)')
                     ->numeric()
                     ->columnSpan([
                         'default' => 2,

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -31,6 +31,10 @@ class ProductResource extends JsonResource
             'meta_description' => $this->meta_description,
             'price' => $this->price,
             'quantity' => $this->quantity,
+            'weight' => $this->weight,
+            'length' => $this->length,
+            'width' => $this->width,
+            'height' => $this->height,
             'image' => $this->getFirstMediaUrl('images'),
             'images' => $images->map(function ($image) {
                 return [

--- a/database/migrations/2025_07_21_214842_add_weight_and_dimensions_to_products_table.php
+++ b/database/migrations/2025_07_21_214842_add_weight_and_dimensions_to_products_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::table('products', function (Blueprint $table) {
@@ -19,9 +16,6 @@ return new class extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::table('products', function (Blueprint $table) {

--- a/database/migrations/2025_07_21_214842_add_weight_and_dimensions_to_products_table.php
+++ b/database/migrations/2025_07_21_214842_add_weight_and_dimensions_to_products_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->decimal('weight', 10, 2)->nullable()->after('quantity');
+            $table->decimal('length', 10, 2)->nullable()->after('weight');
+            $table->decimal('width', 10, 2)->nullable()->after('length');
+            $table->decimal('height', 10, 2)->nullable()->after('width');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn(['weight', 'length', 'width', 'height']);
+        });
+    }
+};

--- a/resources/js/Pages/Product/Show.tsx
+++ b/resources/js/Pages/Product/Show.tsx
@@ -221,6 +221,13 @@ function Show({
             }
             {renderAddToCartButton()}
 
+            {product.weight &&
+              <div className="mb-2">Weight: {product.weight}</div>
+            }
+            {(product.length || product.width || product.height) &&
+              <div className="mb-4">Dimensions: {product.length} x {product.width} x {product.height}</div>
+            }
+
             <b className="text-xl">About the Item</b>
             <div
               className="wysiwyg-output overflow-x-hidden break-words"

--- a/resources/js/Pages/Product/Show.tsx
+++ b/resources/js/Pages/Product/Show.tsx
@@ -222,10 +222,10 @@ function Show({
             {renderAddToCartButton()}
 
             {product.weight &&
-              <div className="mb-2">Weight: {product.weight}</div>
+              <div className="mb-2">Weight: {product.weight} kg</div>
             }
             {(product.length || product.width || product.height) &&
-              <div className="mb-4">Dimensions: {product.length} x {product.width} x {product.height}</div>
+              <div className="mb-4">Dimensions: {product.length} x {product.width} x {product.height} cm</div>
             }
 
             <b className="text-xl">About the Item</b>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -43,6 +43,10 @@ export type Product = {
   slug: string;
   price: number;
   quantity: number;
+  weight: number;
+  length: number;
+  width: number;
+  height: number;
   image: string;
   images: Image[];
   short_description: string;


### PR DESCRIPTION
## Summary
- allow vendors to enter physical attributes for products
- expose weight & dimensions in product API resource
- display physical info on product page before the description
- update TypeScript type definitions
- migration for new columns

## Testing
- `./vendor/bin/pest` *(fails: SQLite database missing)*

------
https://chatgpt.com/codex/tasks/task_e_687eb549c7148323953a4c963d41f41f