### PR TITLE
Add VAT price to search index

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -230,17 +230,19 @@ class Product extends Model implements HasMedia
     public function toSearchableArray()
     {
         $this->load(['category', 'department', 'user']);
-        $price = (float) $this->getPriceForFirstOptions();
-        $gross = app(\App\Services\VatService::class)
-            ->calculate($price, $this->vat_rate_type)['gross'];
+
+        $netPrice = (float) $this->getPriceForFirstOptions();
+        $grossPrice = app(\App\Services\VatService::class)
+            ->calculate($netPrice, $this->vat_rate_type)['gross'];
 
         return [
             'id' => (string)$this->id,
             'title' => $this->title,
             'description' => $this->description,
             'slug' => $this->slug,
-            'price' => $gross,
-            'net_price' => $price,
+            'price' => $grossPrice,
+            'gross_price' => $grossPrice,
+            'net_price' => $netPrice,
             'vat_rate_type' => $this->vat_rate_type,
             'quantity' => $this->quantity,
             'image' => $this->getFirstImageUrl(),

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -230,7 +230,7 @@ class Product extends Model implements HasMedia
     public function toSearchableArray()
     {
         $this->load(['category', 'department', 'user']);
-        $price = (float)$this->getPriceForFirstOptions();
+        $price = (float) $this->getPriceForFirstOptions();
         $gross = app(\App\Services\VatService::class)
             ->calculate($price, $this->vat_rate_type)['gross'];
 
@@ -239,8 +239,8 @@ class Product extends Model implements HasMedia
             'title' => $this->title,
             'description' => $this->description,
             'slug' => $this->slug,
-            'price' => $price,
-            'gross_price' => $gross,
+            'price' => $gross,
+            'net_price' => $price,
             'vat_rate_type' => $this->vat_rate_type,
             'quantity' => $this->quantity,
             'image' => $this->getFirstImageUrl(),

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -230,12 +230,18 @@ class Product extends Model implements HasMedia
     public function toSearchableArray()
     {
         $this->load(['category', 'department', 'user']);
+        $price = (float)$this->getPriceForFirstOptions();
+        $gross = app(\App\Services\VatService::class)
+            ->calculate($price, $this->vat_rate_type)['gross'];
+
         return [
             'id' => (string)$this->id,
             'title' => $this->title,
             'description' => $this->description,
             'slug' => $this->slug,
-            'price' => (float)$this->getPriceForFirstOptions(),
+            'price' => $price,
+            'gross_price' => $gross,
+            'vat_rate_type' => $this->vat_rate_type,
             'quantity' => $this->quantity,
             'image' => $this->getFirstImageUrl(),
             'user_id' => (string)$this->user->id,

--- a/config/scout.php
+++ b/config/scout.php
@@ -213,6 +213,14 @@ return [
                             'facet' => true,
                         ],
                         [
+                            'name' => 'gross_price',
+                            'type' => 'float',
+                        ],
+                        [
+                            'name' => 'vat_rate_type',
+                            'type' => 'string',
+                        ],
+                        [
                             'name' => 'created_at',
                             'type' => 'int64',
                         ],


### PR DESCRIPTION
## Summary
- include VAT rate in product searchable array
- expose `gross_price` and `vat_rate_type` fields to Typesense

## Testing
- `composer install`
- `npm install`
- `./vendor/bin/pest` *(fails: Database file at path `/workspace/marketplace/database/database.sqlite` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687f0a7aaed88323b48d7f7b2c285c05