### PR TITLE
Fix price display on homepage

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -230,12 +230,20 @@ class Product extends Model implements HasMedia
     public function toSearchableArray()
     {
         $this->load(['category', 'department', 'user']);
+
+        $netPrice = (float) $this->getPriceForFirstOptions();
+        $grossPrice = app(\App\Services\VatService::class)
+            ->calculate($netPrice, $this->vat_rate_type)['gross'];
+
         return [
             'id' => (string)$this->id,
             'title' => $this->title,
             'description' => $this->description,
             'slug' => $this->slug,
-            'price' => (float)$this->getPriceForFirstOptions(),
+            'price' => $grossPrice,
+            'gross_price' => $grossPrice,
+            'net_price' => $netPrice,
+            'vat_rate_type' => $this->vat_rate_type,
             'quantity' => $this->quantity,
             'image' => $this->getFirstImageUrl(),
             'user_id' => (string)$this->user->id,

--- a/config/scout.php
+++ b/config/scout.php
@@ -213,6 +213,14 @@ return [
                             'facet' => true,
                         ],
                         [
+                            'name' => 'gross_price',
+                            'type' => 'float',
+                        ],
+                        [
+                            'name' => 'vat_rate_type',
+                            'type' => 'string',
+                        ],
+                        [
                             'name' => 'created_at',
                             'type' => 'int64',
                         ],

--- a/resources/js/Components/App/ProductItem.tsx
+++ b/resources/js/Components/App/ProductItem.tsx
@@ -24,8 +24,8 @@ export default function ProductItem({product}: { product: ProductListItem }) {
 
   const displayPrice = Number(
     product.gross_price ??
-    (product as any).gross ??
     product.price ??
+    (product as any).gross ??
     (product as any).gross_raw ??
     0
   );


### PR DESCRIPTION
## Summary
- compute gross price in `toSearchableArray`
- prefer `gross_price` when displaying product prices on the homepage

## Testing
- `composer install --no-interaction --no-progress`
- `npm install --silent`
- `./vendor/bin/pest` *(fails: Database file does not exist)*
- `php artisan scout:flush "App\Models\Product"` *(fails: Please install algolia/algoliasearch-client-php)*
- `php artisan scout:import "App\Models\Product"` *(fails: Database file does not exist)*
- `php artisan tinker --execute="var_export(App\Models\Product::first()?->toSearchableArray());"` *(fails: Database file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687f0a7aaed88323b48d7f7b2c285c05