### PR TITLE
Fix option ID parameter types

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -133,7 +133,7 @@ class Product extends Model implements HasMedia
         return $this->price;
     }
 
-    public function getImageForOptions(array $optionIds = null)
+    public function getImageForOptions(?array $optionIds = null)
     {
         if ($optionIds) {
             $optionIds = array_values($optionIds);
@@ -151,7 +151,7 @@ class Product extends Model implements HasMedia
         return $this->getFirstMediaUrl('images', 'small');
     }
 
-    public function getImagesForOptions(array $optionIds = null)
+    public function getImagesForOptions(?array $optionIds = null)
     {
         if ($optionIds) {
             $optionIds = array_values($optionIds);


### PR DESCRIPTION
## Summary
- declare `?array` types for option ID parameters in `Product`

## Testing
- `vendor/bin/pest` *(fails: `$config must be a string or an array` from Stripe configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687f5b42d8f48323a793a6b1fa27f7e9