### PR TITLE
Fix option image typing and detect country via GeoIP

### DIFF
--- a/app/Http/Middleware/DetectCountry.php
+++ b/app/Http/Middleware/DetectCountry.php
@@ -4,7 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Stevebauman\Location\Facades\Location;
+use GeoIp2\Database\Reader;
 
 class DetectCountry
 {
@@ -12,8 +12,9 @@ class DetectCountry
     {
         if (! session()->has('country_code')) {
             try {
-                $position = Location::get($request->ip());
-                $code = $position?->countryCode ?: 'RO';
+                $reader = new Reader(storage_path('app/GeoLite2-Country.mmdb'));
+                $record = $reader->country($request->ip());
+                $code = $record->country->isoCode ?: 'RO';
             } catch (\Exception $e) {
                 $code = 'RO';
             }

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -80,11 +80,18 @@ class ProductResource extends JsonResource
                 ];
             }),
             'variations' => $this->variations->map(function ($variation) {
+                $calc = app(\App\Services\VatService::class)
+                    ->calculate(
+                        $variation->price !== null ? $variation->price : $this->price,
+                        $this->vat_rate_type
+                    );
+
                 return [
                     'id' => $variation->id,
                     'variation_type_option_ids' => $variation->variation_type_option_ids,
                     'quantity' => $variation->quantity,
                     'price' => $variation->price,
+                    'gross_price' => $calc['gross'],
                 ];
             }),
         ];

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -133,7 +133,7 @@ class Product extends Model implements HasMedia
         return $this->price;
     }
 
-    public function getImageForOptions(array $optionIds = null)
+    public function getImageForOptions(?array $optionIds = null)
     {
         if ($optionIds) {
             $optionIds = array_values($optionIds);
@@ -151,7 +151,7 @@ class Product extends Model implements HasMedia
         return $this->getFirstMediaUrl('images', 'small');
     }
 
-    public function getImagesForOptions(array $optionIds = null)
+    public function getImagesForOptions(?array $optionIds = null)
     {
         if ($optionIds) {
             $optionIds = array_values($optionIds);

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,10 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "ibericode/vat": "^2.0",
         "filament/filament": "^3.2",
         "filament/spatie-laravel-media-library-plugin": "^3.3",
+        "geoip2/geoip2": "^3.2",
+        "ibericode/vat": "^2.0",
         "inertiajs/inertia-laravel": "^1.3",
         "laravel/cashier": "^15.7",
         "laravel/framework": "^11.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b893ca32fd22ebc0de33940aa4a498e",
+    "content-hash": "e3f5f5cabd18c68a442f017a5d05b48a",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",

--- a/resources/js/Pages/Product/Show.tsx
+++ b/resources/js/Pages/Product/Show.tsx
@@ -45,13 +45,13 @@ function Show({
       const optionIds = variation.variation_type_option_ids.sort();
       if (arraysAreEqual(selectedOptionIds, optionIds)) {
         return {
-          price: variation.price,
+          price: variation.gross_price ?? variation.price,
           quantity: variation.quantity === null ? Number.MAX_VALUE : variation.quantity,
         }
       }
     }
     return {
-      price: product.price,
+      price: product.gross_price,
       quantity: product.quantity === null ? Number.MAX_VALUE : product.quantity,
     };
   }, [product, selectedOptions]);


### PR DESCRIPTION
## Summary
- detect the visitor's country code using GeoIP2 database
- declare `?array` types for option image helpers
- expose VAT-inclusive prices on product pages and variations

## Testing
- `composer install --no-interaction --quiet`
- `vendor/bin/pest` *(fails: SQLiteDatabaseDoesNotExistException)*

------
https://chatgpt.com/codex/tasks/task_e_687f5b42d8f48323a793a6b1fa27f7e9