### PR TITLE
Add phone fields to registrations

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -33,12 +33,16 @@ class RegisteredUserController extends Controller
         $request->validate([
             'name' => 'required|string|max:255',
             'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
+            'country_code' => 'required|string|max:5',
+            'phone' => 'required|string|max:20',
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
         $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
+            'country_code' => $request->country_code,
+            'phone' => $request->phone,
             'password' => Hash::make($request->password),
         ]);
 

--- a/app/Http/Controllers/VendorController.php
+++ b/app/Http/Controllers/VendorController.php
@@ -45,6 +45,8 @@ class VendorController extends Controller
                     ->ignore($user->id, 'user_id')
             ],
             'store_address' => 'nullable',
+            'country_code' => 'required|string|max:5',
+            'phone' => 'required|string|max:20',
         ], [
             'store_name.regex' => 'Store Name must only contain lowercase alphanumeric characters and dashes.',
         ]);
@@ -53,6 +55,8 @@ class VendorController extends Controller
         $vendor->status = VendorStatusEnum::Approved->value;
         $vendor->store_name = $request->store_name;
         $vendor->store_address = $request->store_address;
+        $vendor->country_code = $request->country_code;
+        $vendor->phone = $request->phone;
         $vendor->save();
 
         $user->assignRole(RolesEnum::Vendor);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -29,6 +29,8 @@ class User extends Authenticatable implements MustVerifyEmail
     protected $fillable = [
         'name',
         'email',
+        'country_code',
+        'phone',
         'password',
     ];
 

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -19,6 +19,8 @@ class Vendor extends Model
         'status',
         'store_name',
         'store_address',
+        'country_code',
+        'phone',
         'cover_image',
         'commission_rate',
     ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,6 +26,8 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
+            'country_code' => '+40',
+            'phone' => fake()->phoneNumber(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/2025_09_30_000001_add_phone_to_users_table.php
+++ b/database/migrations/2025_09_30_000001_add_phone_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('country_code')->nullable()->after('email');
+            $table->string('phone')->nullable()->after('country_code');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['country_code', 'phone']);
+        });
+    }
+};

--- a/database/migrations/2025_09_30_000002_add_phone_to_vendors_table.php
+++ b/database/migrations/2025_09_30_000002_add_phone_to_vendors_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('vendors', function (Blueprint $table) {
+            $table->string('country_code')->nullable()->after('store_address');
+            $table->string('phone')->nullable()->after('country_code');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('vendors', function (Blueprint $table) {
+            $table->dropColumn(['country_code', 'phone']);
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
                 "daisyui": "^4.12.14",
                 "react-instantsearch": "^7.15.7",
                 "swiper": "^11.2.6",
-                "typesense-instantsearch-adapter": "^2.9.0"
+                "typesense-instantsearch-adapter": "^2.9.0",
+                "ziggy-js": "^2.5.3"
             },
             "devDependencies": {
                 "@headlessui/react": "^2.0.0",
@@ -4434,6 +4435,28 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/ziggy-js": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/ziggy-js/-/ziggy-js-2.5.3.tgz",
+            "integrity": "sha512-fdlGmRpG6I7yqGicIm6xYXhfbYZHjjb5fPHF5xekK6RLQRgOgLXzEg1R6GUgmF3qPAuKTHhAJ3EUfZ86LyMGeg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/qs": "^6.9.17",
+                "qs": "~6.9.7"
+            }
+        },
+        "node_modules/ziggy-js/node_modules/qs": {
+            "version": "6.9.7",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+            "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
         "@babel/runtime": "^7.27.1",
         "@heroicons/react": "^2.2.0",
         "@tailwindcss/typography": "^0.5.15",
-        "swiper": "^11.2.6",
         "daisyui": "^4.12.14",
         "react-instantsearch": "^7.15.7",
-        "typesense-instantsearch-adapter": "^2.9.0"
+        "swiper": "^11.2.6",
+        "typesense-instantsearch-adapter": "^2.9.0",
+        "ziggy-js": "^2.5.3"
     }
 }

--- a/resources/js/Pages/Auth/Register.tsx
+++ b/resources/js/Pages/Auth/Register.tsx
@@ -4,6 +4,7 @@ import PrimaryButton from '@/Components/Core/PrimaryButton';
 import TextInput from '@/Components/Core/TextInput';
 import GuestLayout from '@/Layouts/GuestLayout';
 import {Head, Link, useForm} from '@inertiajs/react';
+import {countryCodes} from '@/data/countryCodes';
 import {FormEventHandler} from 'react';
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
 
@@ -11,6 +12,8 @@ export default function Register() {
   const {data, setData, post, processing, errors, reset} = useForm({
     name: '',
     email: '',
+    country_code: '+40',
+    phone: '',
     password: '',
     password_confirmation: '',
   });
@@ -65,6 +68,42 @@ export default function Register() {
                 />
 
                 <InputError message={errors.email} className="mt-2"/>
+              </div>
+
+              <div className="mt-4">
+                <InputLabel htmlFor="country_code" value="Country Code"/>
+
+                <select
+                  id="country_code"
+                  name="country_code"
+                  value={data.country_code}
+                  className="select select-bordered w-full mt-1"
+                  onChange={(e) => setData('country_code', e.target.value)}
+                  required>
+                  {countryCodes.map((c) => (
+                    <option key={c.code} value={c.code}>
+                      {c.name} ({c.code})
+                    </option>
+                  ))}
+                </select>
+
+                <InputError message={errors.country_code} className="mt-2"/>
+              </div>
+
+              <div className="mt-4">
+                <InputLabel htmlFor="phone" value="Phone"/>
+
+                <TextInput
+                  id="phone"
+                  name="phone"
+                  value={data.phone}
+                  className="mt-1 block w-full"
+                  autoComplete="tel"
+                  onChange={(e) => setData('phone', e.target.value)}
+                  required
+                />
+
+                <InputError message={errors.phone} className="mt-2"/>
               </div>
 
               <div className="mt-4">

--- a/resources/js/Pages/Profile/Partials/VendorDetails.tsx
+++ b/resources/js/Pages/Profile/Partials/VendorDetails.tsx
@@ -6,6 +6,7 @@ import Modal from "@/Components/Core/Modal";
 import InputLabel from "@/Components/Core/InputLabel";
 import TextInput from "@/Components/Core/TextInput";
 import InputError from "@/Components/Core/InputError";
+import {countryCodes} from '@/data/countryCodes';
 
 export default function VendorDetails(
   {className = '',}: { className?: string; }
@@ -24,7 +25,9 @@ export default function VendorDetails(
     recentlySuccessful,
   } = useForm({
     store_name: user.vendor?.store_name || user.name.toLowerCase().replace(/\s+/g, '-'),
-    store_address: user.vendor?.store_address
+    store_address: user.vendor?.store_address,
+    country_code: user.vendor?.country_code || user.country_code,
+    phone: user.vendor?.phone || user.phone
   });
 
   const onStoreNameChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
@@ -118,6 +121,42 @@ export default function VendorDetails(
                   placeholder="Enter Your Store Address"></textarea>
 
                 <InputError className="mt-2" message={errors.store_address}/>
+              </div>
+
+              <div className="mb-4">
+                <InputLabel htmlFor="country_code" value="Country Code"/>
+
+                <select
+                  id="country_code"
+                  name="country_code"
+                  value={data.country_code}
+                  className="select select-bordered w-full mt-1"
+                  onChange={(e) => setData('country_code', e.target.value)}
+                  required>
+                  {countryCodes.map(c => (
+                    <option key={c.code} value={c.code}>
+                      {c.name} ({c.code})
+                    </option>
+                  ))}
+                </select>
+
+                <InputError className="mt-2" message={errors.country_code}/>
+              </div>
+
+              <div className="mb-4">
+                <InputLabel htmlFor="phone" value="Phone"/>
+
+                <TextInput
+                  id="phone"
+                  name="phone"
+                  value={data.phone}
+                  className="mt-1 block w-full"
+                  autoComplete="tel"
+                  onChange={(e) => setData('phone', e.target.value)}
+                  required
+                />
+
+                <InputError className="mt-2" message={errors.phone}/>
               </div>
               <div className="flex items-center gap-4">
                 <PrimaryButton disabled={processing}>Update</PrimaryButton>

--- a/resources/js/data/countryCodes.ts
+++ b/resources/js/data/countryCodes.ts
@@ -1,0 +1,5 @@
+export const countryCodes = [
+  { code: '+40', name: 'Romania' },
+  { code: '+359', name: 'Bulgaria' },
+  { code: '+36', name: 'Hungary' },
+];

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -3,7 +3,7 @@ import createServer from '@inertiajs/react/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import ReactDOMServer from 'react-dom/server';
 import { RouteName } from 'ziggy-js';
-import { route } from '../../vendor/tightenco/ziggy';
+import { route } from 'ziggy-js';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -4,6 +4,8 @@ export interface User {
   id: number;
   name: string;
   email: string;
+  country_code: string;
+  phone: string;
   email_verified_at?: string;
   stripe_account_active: boolean;
   roles: string[];
@@ -12,6 +14,8 @@ export interface User {
     status_label: string;
     store_name: string;
     store_address: string;
+    country_code: string;
+    phone: string;
     cover_image: string;
   }
 }
@@ -192,6 +196,8 @@ export type Vendor = {
   id: number;
   store_name: string;
   store_address: string;
+  country_code: string;
+  phone: string;
 }
 
 export type Category = {

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -10,6 +10,8 @@ test('new users can register', function () {
     $response = $this->post('/register', [
         'name' => 'Test User',
         'email' => 'test@example.com',
+        'country_code' => '+40',
+        'phone' => '0712345678',
         'password' => 'password',
         'password_confirmation' => 'password',
     ]);


### PR DESCRIPTION
## Summary
- add migrations for phone numbers
- allow phone and country code during user registration
- allow phone and country code when registering a vendor
- expose phone fields in models and factories
- collect phone info on frontend forms
- adjust TypeScript interfaces
- update registration test
- restrict selectable country phone prefixes to Romania, Bulgaria and Hungary
- fix Ziggy module import for build

## Testing
- `npm run build`
- `DB_CONNECTION=sqlite DB_DATABASE=database/database.sqlite ./vendor/bin/pest` *(fails: InvalidArgumentException / database setup)*

------
https://chatgpt.com/codex/tasks/task_e_687f79b5c62883239acbeb2b5f49738d