### PR TITLE
Limit phone codes to Romania, Bulgaria & Hungary

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,7 +26,7 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'country_code' => '+1',
+            'country_code' => '+40',
             'phone' => fake()->phoneNumber(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),

--- a/resources/js/Pages/Auth/Register.tsx
+++ b/resources/js/Pages/Auth/Register.tsx
@@ -12,7 +12,7 @@ export default function Register() {
   const {data, setData, post, processing, errors, reset} = useForm({
     name: '',
     email: '',
-    country_code: '+1',
+    country_code: '+40',
     phone: '',
     password: '',
     password_confirmation: '',

--- a/resources/js/data/countryCodes.ts
+++ b/resources/js/data/countryCodes.ts
@@ -1,6 +1,5 @@
 export const countryCodes = [
-  { code: '+1', name: 'USA/Canada' },
-  { code: '+44', name: 'UK' },
-  { code: '+91', name: 'India' },
-  { code: '+234', name: 'Nigeria' },
+  { code: '+40', name: 'Romania' },
+  { code: '+359', name: 'Bulgaria' },
+  { code: '+36', name: 'Hungary' },
 ];

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -10,7 +10,7 @@ test('new users can register', function () {
     $response = $this->post('/register', [
         'name' => 'Test User',
         'email' => 'test@example.com',
-        'country_code' => '+1',
+        'country_code' => '+40',
         'phone' => '1234567890',
         'password' => 'password',
         'password_confirmation' => 'password',


### PR DESCRIPTION
## Summary
- trim available phone codes to RO, BG, and HU only
- update registration default and tests
- adjust user factory default country code

## Testing
- `composer install`
- `vendor/bin/pest` *(fails: InvalidArgumentException due to Stripe config)*

------
https://chatgpt.com/codex/tasks/task_e_687f8253031c8323bd464d8faa14d72c