### PR TITLE
Show country in dashboard

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -72,6 +72,7 @@ class HandleInertiaRequests extends Middleware
             'miniCartItems' => $cartItems,
             'departments' => DepartmentResource::collection($departments)->collection->toArray(),
             'keyword' => $request->query('keyword'),
+            'countryCode' => session('country_code'),
         ];
     }
 }

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -1,7 +1,10 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import {Head} from '@inertiajs/react';
+import {Head, usePage} from '@inertiajs/react';
+import {PageProps} from '@/types';
 
 export default function Dashboard() {
+  const { countryCode } = usePage<PageProps>().props
+
   return (
     <AuthenticatedLayout
       header={
@@ -15,8 +18,9 @@ export default function Dashboard() {
       <div className="py-12">
         <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
           <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
-            <div className="p-6 text-gray-900 dark:text-gray-100">
-              You're logged in!
+            <div className="p-6 text-gray-900 dark:text-gray-100 space-y-2">
+              <p>You're logged in!</p>
+              <p>Country code: {countryCode}</p>
             </div>
           </div>
         </div>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -158,6 +158,7 @@ export type PageProps<
   miniCartItems: CartItem[];
   departments: Department[];
   keyword: string;
+  countryCode: string;
 };
 
 


### PR DESCRIPTION
## Summary
- expose the visitor's country code through the Inertia middleware
- display the country code in the Dashboard page for debugging
- extend PageProps definition with `countryCode`

## Testing
- `npx tsc -p tsconfig.json`
- `./vendor/bin/pest` *(fails: SQLite database not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f859088f483238e14f0128f965216