### PR TITLE
Add related products section

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -42,10 +42,18 @@ class ProductController extends Controller
                 ->exists();
         }
 
+        $relatedProducts = Product::query()
+            ->forWebsite()
+            ->where('category_id', $product->category_id)
+            ->where('id', '!=', $product->id)
+            ->take(10)
+            ->get();
+
         return Inertia::render('Product/Show', [
             'product' => new ProductResource($product),
             'variationOptions' => request('options', []),
             'hasPurchased' => $hasPurchased,
+            'relatedProducts' => ProductListResource::collection($relatedProducts),
         ]);
     }
 

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -41,6 +41,7 @@ class ProductResource extends JsonResource
 
             // Imagine principală
             'image'             => $this->getFirstMediaUrl('images'),
+            'main_image_url'    => $this->getFirstMediaUrl('images'),
 
             // Galerie imagini
             'images' => $images->map(function ($image) {

--- a/resources/js/Pages/Product/Show.tsx
+++ b/resources/js/Pages/Product/Show.tsx
@@ -1,4 +1,4 @@
-import {PageProps, Product, VariationTypeOption} from "@/types";
+import {PageProps, Product, VariationTypeOption, ProductListItem} from "@/types";
 import {Head, Link, router, useForm, usePage} from "@inertiajs/react";
 import {useEffect, useMemo, useState} from "react";
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
@@ -12,11 +12,12 @@ import PrimaryButton from "@/Components/Core/PrimaryButton";
 import InputError from "@/Components/Core/InputError";
 
 function Show({
-                appName, product, variationOptions, hasPurchased
+                appName, product, variationOptions, hasPurchased, relatedProducts
 }: PageProps<{
   product: Product,
   variationOptions: number[],
-  hasPurchased: boolean
+  hasPurchased: boolean,
+  relatedProducts: ProductListItem[]
 }>) {
 
   const form = useForm<{
@@ -265,6 +266,27 @@ function Show({
           </div>
         </div>
       </div>
+      {relatedProducts.length > 0 && (
+        <div className="container mx-auto px-8 mt-12">
+          <h2 className="text-xl font-semibold mb-4">Îți mai recomandăm și:</h2>
+          <div className="flex gap-4 overflow-x-auto">
+            {relatedProducts.map(rp => (
+              <div key={rp.id} className="min-w-[200px] bg-white shadow rounded p-4">
+                <img src={rp.image} alt={rp.title} className="w-full h-40 object-cover rounded" />
+                <div className="mt-2">
+                  <h3 className="text-sm font-medium">{rp.title}</h3>
+                  <p className="text-purple-600 font-semibold mt-1">
+                    <CurrencyFormatter amount={rp.gross_price ?? rp.price} />
+                  </p>
+                  <Link href={`/product/${rp.slug}`} className="text-sm text-blue-500 mt-2 inline-block">
+                    Vezi produsul
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
       <Modal show={showReviews} onClose={() => setShowReviews(false)}>
         <div className="p-4">
           <h3 className="text-xl mb-4">Reviews</h3>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -63,6 +63,7 @@ export type Product = {
   width: number;
   height: number;
   image: string;
+  main_image_url: string;
   images: Image[];
   short_description: string;
   description: string;


### PR DESCRIPTION
## Summary
- add related products logic in controller
- expose `main_image_url` in product resource
- extend Product type
- render "Îți mai recomandăm și" section in product page

## Testing
- `php artisan test` *(fails: SQLite database does not exist / Stripe config)*
- `npm run build` *(fails: TS errors in StarRating.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688140301bfc8323aa02fad3cf609bd3