### PR TITLE
Fix price display on homepage

### DIFF
--- a/app/Http/Resources/ProductListResource.php
+++ b/app/Http/Resources/ProductListResource.php
@@ -41,6 +41,7 @@ class ProductListResource extends JsonResource
             'net'                => $netFormatted,
             'vat'                => $vatFormatted,
             'gross'              => $grossFormatted,
+            'vat_rate_type'      => $this->vat_rate_type,
 
             'quantity'           => $this->quantity,
             'image'              => $this->getFirstImageUrl(),

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -133,7 +133,7 @@ class Product extends Model implements HasMedia
         return $this->price;
     }
 
-    public function getImageForOptions(array $optionIds = null)
+    public function getImageForOptions(?array $optionIds = null)
     {
         if ($optionIds) {
             $optionIds = array_values($optionIds);
@@ -151,7 +151,7 @@ class Product extends Model implements HasMedia
         return $this->getFirstMediaUrl('images', 'small');
     }
 
-    public function getImagesForOptions(array $optionIds = null)
+    public function getImagesForOptions(?array $optionIds = null)
     {
         if ($optionIds) {
             $optionIds = array_values($optionIds);
@@ -230,12 +230,14 @@ class Product extends Model implements HasMedia
     public function toSearchableArray()
     {
         $this->load(['category', 'department', 'user']);
+
         return [
             'id' => (string)$this->id,
             'title' => $this->title,
             'description' => $this->description,
             'slug' => $this->slug,
             'price' => (float)$this->getPriceForFirstOptions(),
+            'vat_rate_type' => $this->vat_rate_type,
             'quantity' => $this->quantity,
             'image' => $this->getFirstImageUrl(),
             'user_id' => (string)$this->user->id,

--- a/config/scout.php
+++ b/config/scout.php
@@ -213,6 +213,10 @@ return [
                             'facet' => true,
                         ],
                         [
+                            'name' => 'vat_rate_type',
+                            'type' => 'string',
+                        ],
+                        [
                             'name' => 'created_at',
                             'type' => 'int64',
                         ],

--- a/resources/js/Components/App/MiniCartDropdown.tsx
+++ b/resources/js/Components/App/MiniCartDropdown.tsx
@@ -5,7 +5,7 @@ import {productRoute} from "@/helpers";
 
 function MiniCartDropdown() {
 
-  const {totalQuantity, totalPrice, miniCartItems} = usePage().props
+  const {totalQuantity, totalGross, miniCartItems} = usePage().props
 
   return (
     <details className="dropdown dropdown-end static sm:relative ">
@@ -60,7 +60,7 @@ function MiniCartDropdown() {
                     </div>
                     <div>
                       <CurrencyFormatter
-                        amount={item.quantity * item.price}/>
+                        amount={item.quantity * item.gross_price}/>
                     </div>
                   </div>
                 </div>
@@ -69,7 +69,7 @@ function MiniCartDropdown() {
           </div>
 
           <span className="text-lg">
-            Subtotal: <CurrencyFormatter amount={totalPrice}/>
+            Subtotal: <CurrencyFormatter amount={totalGross}/>
           </span>
           <div className="card-actions">
             <Link href={route('cart.index')}

--- a/resources/js/Components/App/ProductItem.tsx
+++ b/resources/js/Components/App/ProductItem.tsx
@@ -2,6 +2,18 @@ import {Product, ProductListItem} from "@/types";
 import {Link, useForm} from "@inertiajs/react";
 import CurrencyFormatter from "@/Components/Core/CurrencyFormatter";
 
+const getVatMultiplier = (country: string, vatType: string) => {
+  const rates: Record<string, Record<string, number>> = {
+    ro: { standard: 1.19 },
+    hu: { standard: 1.27 },
+    bg: { standard: 1.20 },
+  };
+
+  const defaultRate = 1.20;
+  const countryRates = rates[country.toLowerCase()] ?? {};
+  return countryRates[vatType] ?? defaultRate;
+};
+
 export default function ProductItem({product}: { product: ProductListItem }) {
 
   const form = useForm<{
@@ -22,13 +34,10 @@ export default function ProductItem({product}: { product: ProductListItem }) {
     })
   }
 
-  const displayPrice = Number(
-    product.gross_price ??
-    (product as any).gross ??
-    product.price ??
-    (product as any).gross_raw ??
-    0
-  );
+  const country = localStorage.getItem('user_country') || 'ro';
+  const vatMultiplier = getVatMultiplier(country, product.vat_rate_type);
+  const displayPrice =
+    Number(product.price ?? (product as any).net_raw ?? 0) * vatMultiplier;
 
   return (
     <div className="card bg-base-100 shadow">

--- a/resources/js/Pages/Product/Show.tsx
+++ b/resources/js/Pages/Product/Show.tsx
@@ -41,17 +41,19 @@ function Show({
       .map(op => op.id)
       .sort();
 
+    const multiplier = product.price > 0 ? product.gross_price / product.price : 1;
+
     for (let variation of product.variations) {
       const optionIds = variation.variation_type_option_ids.sort();
       if (arraysAreEqual(selectedOptionIds, optionIds)) {
         return {
-          price: variation.price,
+          price: variation.price * multiplier,
           quantity: variation.quantity === null ? Number.MAX_VALUE : variation.quantity,
         }
       }
     }
     return {
-      price: product.price,
+      price: product.gross_price,
       quantity: product.quantity === null ? Number.MAX_VALUE : product.quantity,
     };
   }, [product, selectedOptions]);

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -43,6 +43,7 @@ export type Product = {
   slug: string;
   price: number;
   gross_price: number;
+  vat_rate_type: string;
   quantity: number;
   weight: number;
   length: number;
@@ -80,6 +81,7 @@ export type ProductListItem = {
   slug: string;
   price: number;
   gross_price: number;
+  vat_rate_type: string;
   quantity: number;
   image: string;
   user_id: number;


### PR DESCRIPTION
## Summary
- compute gross price dynamically on the frontend
- expose `vat_rate_type` in product list API
- keep search index net priced and typed
- add VAT helper for product cards

## Testing
- `composer install --no-interaction --no-progress`
- `npm install --silent` *(no output)*
- `./vendor/bin/pest` *(fails: Database file does not exist)*
- `php artisan scout:flush "App\Models\Product"` *(fails: Please install algolia/algoliasearch-client-php)*
- `php artisan scout:import "App\Models\Product"` *(fails: Database file does not exist)*
- `php artisan tinker --execute="var_export(App\Models\Product::first()?->toSearchableArray());"` *(fails: Database file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687f0a7aaed88323b48d7f7b2c285c05