### PR TITLE
Add Stripe payment failure view

### DIFF
--- a/app/Http/Controllers/StripeController.php
+++ b/app/Http/Controllers/StripeController.php
@@ -40,7 +40,7 @@ class StripeController extends Controller
 
     public function failure()
     {
-
+        return Inertia::render('Stripe/Failure');
     }
 
     public function webhook(Request $request)

--- a/resources/js/Pages/Stripe/Failure.tsx
+++ b/resources/js/Pages/Stripe/Failure.tsx
@@ -1,0 +1,31 @@
+import {Head, Link} from "@inertiajs/react";
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
+import {XCircleIcon} from "@heroicons/react/24/outline";
+import {PageProps} from "@/types";
+
+export default function Failure({}: PageProps) {
+  return (
+    <AuthenticatedLayout>
+      <Head title="Payment Failed" />
+      <div className="w-[480px] mx-auto py-8 px-4">
+        <div className="flex flex-col gap-2 items-center">
+          <div className="text-6xl text-red-500">
+            <XCircleIcon className="size-24" />
+          </div>
+          <div className="text-3xl">Payment Failed</div>
+        </div>
+        <div className="my-6 text-lg">
+          Something went wrong with your payment. You can return to your cart or go back to your dashboard.
+        </div>
+        <div className="flex justify-between">
+          <Link href={route('cart.index')} className="btn btn-primary">
+            Back to Cart
+          </Link>
+          <Link href={route('dashboard')} className="btn">
+            Dashboard
+          </Link>
+        </div>
+      </div>
+    </AuthenticatedLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- return an Inertia page from `StripeController::failure`
- add new page `Stripe/Failure` with payment error message and links

## Testing
- `php artisan test` *(fails: database path not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f7224cec83239268c80b3cc1bde7