### PR TITLE
Fix fall-through in Stripe webhook cases

### DIFF
--- a/app/Http/Controllers/StripeController.php
+++ b/app/Http/Controllers/StripeController.php
@@ -102,6 +102,7 @@ class StripeController extends Controller
 
                 Mail::to($orders[0]->user)->send(new CheckoutCompleted($orders));
 
+                break;
 
             case 'checkout.session.completed':
                 $session = $event->data->object;
@@ -152,6 +153,8 @@ class StripeController extends Controller
                     ->whereIn('product_id', $productsToDeletedFromCart)
                     ->where('saved_for_later', false)
                     ->delete();
+
+                break;
 
             default:
                 echo 'Received unknown event type ' . $event->type;


### PR DESCRIPTION
## Summary
- prevent switch case fall-through in `StripeController`

## Testing
- `composer install --no-interaction --no-progress`
- `./vendor/bin/pest` *(fails: InvalidArgumentException, missing DB)*

------
https://chatgpt.com/codex/tasks/task_e_6881f7244ff883239859e32e2a4d1e63