### PR TITLE
Add country code handling for products

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -28,6 +28,7 @@ class ProductController extends Controller
 
         return Inertia::render('Home', [
             'products' => ProductListResource::collection($products),
+            'countryCode' => session('country_code'),
         ]);
     }
 

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -246,7 +246,7 @@ class Product extends Model implements HasMedia
 
         $netPrice = (float) $this->getPriceForFirstOptions();
         $grossPrice = app(\App\Services\VatService::class)
-            ->calculate($netPrice, $this->vat_rate_type)['gross'];
+            ->calculate($netPrice, $this->vat_rate_type, session('country_code'))['gross'];
 
         return [
             'id' => (string) $this->id,

--- a/resources/js/Components/App/ProductItem.tsx
+++ b/resources/js/Components/App/ProductItem.tsx
@@ -1,9 +1,8 @@
 import { ProductListItem } from "@/types";
 import { Link, useForm } from "@inertiajs/react";
 import CurrencyFormatter from "@/Components/Core/CurrencyFormatter";
-import { useEffect } from "react";
 
-export default function ProductItem({ product }: { product: ProductListItem }) {
+export default function ProductItem({ product, countryCode }: { product: ProductListItem; countryCode: string }) {
   const form = useForm<{
     option_ids: Record<string, number>;
     quantity: number;
@@ -12,9 +11,6 @@ export default function ProductItem({ product }: { product: ProductListItem }) {
     quantity: 1,
   });
 
-  useEffect(() => {
-    console.log("PRODUCT DEBUG:", product);
-  }, [product]);
 
   const addToCart = () => {
     form.post(route("cart.store", product.id), {

--- a/resources/js/Components/App/ProductListing.tsx
+++ b/resources/js/Components/App/ProductListing.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import ProductItem from "@/Components/App/ProductItem";
-import {Link} from "@inertiajs/react";
-import {PaginationProps, ProductListItem} from "@/types";
+import {Link, usePage} from "@inertiajs/react";
+import {PaginationProps, ProductListItem, PageProps} from "@/types";
 
 function ProductListing({products}: { products: PaginationProps<ProductListItem> }) {
+  const {countryCode} = usePage<PageProps>().props;
   return (
     <div className="container py-8 px-4 mx-auto">
       {products.data.length === 0 && (
@@ -13,7 +14,7 @@ function ProductListing({products}: { products: PaginationProps<ProductListItem>
       )}
       <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
         {products.data.map(product => (
-          <ProductItem product={product} key={product.id}/>
+          <ProductItem product={product} key={product.id} countryCode={countryCode}/>
         ))}
       </div>
       {/*<pre>{JSON.stringify(products, undefined, 2)}</pre>*/}

--- a/resources/js/Pages/Home.tsx
+++ b/resources/js/Pages/Home.tsx
@@ -13,7 +13,7 @@ import NumberFormatter from "@/Components/Core/NumberFormatter";
 import ProductListing from "@/Components/App/ProductListing";
 import BannerSlider from "@/Components/App/BannerSlider";
 
-function CustomHits() {
+function CustomHits({ countryCode }: { countryCode: string }) {
   const { hits, results } = useHits();
 
   if (!results || results.nbHits === 0) {
@@ -57,7 +57,7 @@ function CustomHits() {
       </div>
       <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
         {hits.map((hit: any) => (
-          <ProductItem product={hit} key={hit.id} />
+          <ProductItem product={hit} key={hit.id} countryCode={countryCode} />
         ))}
       </div>
     </>
@@ -92,8 +92,9 @@ const sampleBanners = [
 ];
 
 export default function Home({
-                               products
-                             }: PageProps<{ products: PaginationProps<Product> }>) {
+                               products,
+                               countryCode
+                             }: PageProps<{ products: PaginationProps<Product>; countryCode: string }>) {
 
   return (
     <AuthenticatedLayout>
@@ -106,7 +107,7 @@ export default function Home({
 
           <div className="flex-1">
             <Configure hitsPerPage={24} />
-            <CustomHits />
+            <CustomHits countryCode={countryCode} />
             <Pagination
               classNames={{
                 root: 'hidden justify-center md:flex',


### PR DESCRIPTION
## Summary
- calculate VAT using session country when building product search data
- forward `countryCode` from backend to Home page
- pass `countryCode` through product listing components

## Testing
- `npm run build` *(fails: TS errors)*
- `./vendor/bin/pest` *(fails: database file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68824d742da48323a8e7b2729a0ced10