### PR TITLE
Add vendor details page with Stripe connect

### DIFF
--- a/app/Http/Controllers/VendorController.php
+++ b/app/Http/Controllers/VendorController.php
@@ -57,4 +57,9 @@ class VendorController extends Controller
 
         $user->assignRole(RolesEnum::Vendor);
     }
+
+    public function details()
+    {
+        return Inertia::render('Vendor/Details');
+    }
 }

--- a/resources/js/Pages/Vendor/Details.tsx
+++ b/resources/js/Pages/Vendor/Details.tsx
@@ -1,0 +1,23 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+import VendorDetails from '@/Pages/Profile/Partials/VendorDetails';
+
+export default function Details() {
+  return (
+    <AuthenticatedLayout
+      header={
+        <h2 className="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-200">
+          Vendor Details
+        </h2>
+      }
+    >
+      <Head title="Vendor Details" />
+
+      <div className="py-8">
+        <div className="mx-auto max-w-2xl bg-white p-4 shadow sm:rounded-lg dark:bg-gray-800">
+          <VendorDetails />
+        </div>
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,6 +78,10 @@ Route::middleware('auth')->group(function () {
         Route::post('/stripe/connect', [StripeController::class, 'connect'])
             ->name('stripe.connect')
             ->middleware(['role:' . \App\Enums\RolesEnum::Vendor->value]);
+
+        Route::get('/vendor/details', [VendorController::class, 'details'])
+            ->name('vendor.details')
+            ->middleware(['role:' . \App\Enums\RolesEnum::Vendor->value]);
     });
 });
 


### PR DESCRIPTION
## Summary
- allow vendors to manage their details on a new page
- add route and controller method for vendor details

## Testing
- `composer install`
- `./vendor/bin/pest` *(fails: database file does not exist)*
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882d0fd1790832394406b2e50baa31a