### PR TITLE
Fix variant image serialization

### DIFF
--- a/app/Http/Resources/VariationTypeOptionResource.php
+++ b/app/Http/Resources/VariationTypeOptionResource.php
@@ -18,9 +18,18 @@ class VariationTypeOptionResource extends JsonResource
             'id' => $this->id,
             'variation_type_id' => $this->variation_type_id,
             'name' => $this->name,
+            'image' => $this->getFirstMediaUrl('images', 'small'),
+            'images' => $this->getMedia('images')->map(function ($image) {
+                return [
+                    'id' => $image->id,
+                    'thumb' => $image->getUrl('thumb'),
+                    'small' => $image->getUrl('small'),
+                    'large' => $image->getUrl('large'),
+                ];
+            }),
 
             // Include relations
-            'variationType' => $this->whenLoaded('variationType', function() {
+            'variationType' => $this->whenLoaded('variationType', function () {
                 return [
                     'id' => $this->variationType->id,
                     'name' => $this->variationType->name,


### PR DESCRIPTION
## Summary
- include image URLs when serializing variation options so product variants show images

## Testing
- `composer install --no-interaction`
- `./vendor/bin/pint app/Http/Resources/VariationTypeOptionResource.php`
- `./vendor/bin/pest --parallel` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837bf1d6208323b655e051f336b731