### PR TITLE
Add user avatar upload

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -29,13 +29,18 @@ class ProfileController extends Controller
      */
     public function update(ProfileUpdateRequest $request): RedirectResponse
     {
-        $request->user()->fill($request->validated());
+        $user = $request->user();
+        $user->fill($request->safe()->except('avatar'));
 
-        if ($request->user()->isDirty('email')) {
-            $request->user()->email_verified_at = null;
+        if ($request->hasFile('avatar')) {
+            $user->clearMediaCollection('avatar');
+            $user->addMediaFromRequest('avatar')->toMediaCollection('avatar');
+        }
+        if ($user->isDirty('email')) {
+            $user->email_verified_at = null;
         }
 
-        $request->user()->save();
+        $user->save();
 
         return Redirect::route('profile.edit');
     }

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -25,6 +25,7 @@ class ProfileUpdateRequest extends FormRequest
                 'max:255',
                 Rule::unique(User::class)->ignore($this->user()->id),
             ],
+            'avatar' => ['nullable', 'image', 'max:1024'],
         ];
     }
 }

--- a/app/Http/Resources/AuthUserResource.php
+++ b/app/Http/Resources/AuthUserResource.php
@@ -26,14 +26,15 @@ class AuthUserResource extends JsonResource
                 return $permission->name;
             }),
             'roles' => $this->getRoleNames(),
-            'stripe_account_active' => (bool)$this->stripe_account_active,
-            'vendor' => !$this->vendor ? null : [
+            'avatar_url' => $this->avatar_url,
+            'stripe_account_active' => (bool) $this->stripe_account_active,
+            'vendor' => ! $this->vendor ? null : [
                 'status' => $this->vendor->status,
                 'status_label' => VendorStatusEnum::from($this->vendor->status)->label(),
                 'store_name' => $this->vendor->store_name,
                 'store_address' => $this->vendor->store_address,
                 'cover_image' => $this->vendor->cover_image,
-            ]
+            ],
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,12 +14,15 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use SimonHamp\LaravelStripeConnect\Traits\Payable;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable implements MustVerifyEmail
+class User extends Authenticatable implements HasMedia, MustVerifyEmail
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable, HasRoles, Payable;
+    use HasFactory, HasRoles, InteractsWithMedia, Notifiable, Payable;
 
     /**
      * The attributes that are mass assignable.
@@ -81,5 +84,26 @@ class User extends Authenticatable implements MustVerifyEmail
     public function orders(): HasMany
     {
         return $this->hasMany(Order::class);
+    }
+
+    public function registerMediaConversions(?Media $media = null): void
+    {
+        $this->addMediaConversion('thumb')
+            ->width(100)
+            ->nonQueued();
+
+        $this->addMediaConversion('small')
+            ->width(480)
+            ->nonQueued();
+    }
+
+    public function getAvatarUrlAttribute(): ?string
+    {
+        return $this->getFirstMediaUrl('avatar', 'thumb');
+    }
+
+    public function getFilamentAvatarUrl(): ?string
+    {
+        return $this->getFirstMediaUrl('avatar', 'thumb');
     }
 }

--- a/resources/js/Components/App/Navbar.tsx
+++ b/resources/js/Components/App/Navbar.tsx
@@ -52,8 +52,8 @@ function Navbar() {
             <div tabIndex={0} role="button" className="btn btn-ghost btn-circle avatar">
               <div className="w-10 rounded-full">
                 <img
-                  alt="Tailwind CSS Navbar component"
-                  src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp"/>
+                  alt="User avatar"
+                  src={user.avatar_url ?? 'https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp'} />
               </div>
             </div>
             <ul

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
@@ -21,7 +21,14 @@ export default function UpdateProfileInformation({
         useForm({
             name: user.name,
             email: user.email,
+            avatar: null as File | null,
         });
+
+    const onAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files && e.target.files[0]) {
+            setData('avatar', e.target.files[0]);
+        }
+    };
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
@@ -96,6 +103,17 @@ export default function UpdateProfileInformation({
                         )}
                     </div>
                 )}
+
+                <div>
+                    <InputLabel htmlFor="avatar" value="Avatar" />
+                    <input
+                        id="avatar"
+                        type="file"
+                        className="file-input file-input-bordered mt-1 w-full"
+                        onChange={onAvatarChange}
+                    />
+                    <InputError className="mt-2" message={errors.avatar} />
+                </div>
 
                 <div className="flex items-center gap-4">
                     <PrimaryButton disabled={processing}>Save</PrimaryButton>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -5,6 +5,7 @@ export interface User {
   name: string;
   email: string;
   email_verified_at?: string;
+  avatar_url?: string;
   stripe_account_active: boolean;
   roles: string[];
   vendor: {

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -33,6 +33,29 @@ test('profile information can be updated', function () {
     $this->assertNull($user->email_verified_at);
 });
 
+test('profile avatar can be uploaded', function () {
+    \Illuminate\Support\Facades\Storage::fake('public');
+    $user = User::factory()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->patch('/profile', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'avatar' => \Illuminate\Http\UploadedFile::fake()->image('avatar.jpg'),
+        ]);
+
+    $response
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/profile');
+
+    $this->assertDatabaseHas('media', [
+        'model_type' => App\Models\User::class,
+        'model_id' => $user->id,
+        'collection_name' => 'avatar',
+    ]);
+});
+
 test('email verification status is unchanged when the email address is unchanged', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
## Summary
- allow users to upload a profile avatar
- expose avatar URL via API
- show avatar in navbar dropdown
- include avatar field in profile update form
- test uploading avatar

## Testing
- `./vendor/bin/pest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883982f25148323a7088c162b3b2581