### PR TITLE
Fix first options map retrieval

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -192,7 +192,12 @@ class Product extends Model implements HasMedia
     public function getFirstOptionsMap(): array
     {
         return $this->variationTypes
-            ->mapWithKeys(fn($type) => [$type->id => $type->options[0]?->id])
+            ->mapWithKeys(function ($type) {
+                // Use `first()` to avoid accessing a non-existent zero index
+                $firstOptionId = $type->options->first()?->id;
+
+                return [$type->id => $firstOptionId];
+            })
             ->toArray();
     }
 


### PR DESCRIPTION
## Summary
- prevent `Undefined array key 0` when product variation types have no options

## Testing
- `vendor/bin/pest --stop-on-failure --colors=always` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688400381b1c8323b23206ed6f6b3ae0