### PR TITLE
Fix cart totals and update Typesense schema

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -23,11 +23,16 @@ class CartController extends Controller
     {
         [$user, $defaultAddress] = $this->userShippingAddress();
 
+        $totals = $cartService->getTotals();
+
         return Inertia::render('Cart/Index', [
             'cartItems' => $cartService->getCartItemsGrouped(),
             'addresses' => $user ? ShippingAddressResource::collection($user->shippingAddresses)->collection->toArray() : [],
             'shippingAddress' => $defaultAddress ? new ShippingAddressResource($defaultAddress) : null,
             'countryCode' => session('country_code', 'RO'),
+            'gross_total' => $totals['gross_total'],
+            'vat_total' => $totals['vat_total'],
+            'net_total' => $totals['net_total'],
         ]);
     }
 

--- a/app/Services/CartService.php
+++ b/app/Services/CartService.php
@@ -170,6 +170,20 @@ class CartService
         return $this->getTotalGross() - $this->getTotalPrice();
     }
 
+    /**
+     * Returns an array with net, vat and gross totals for the cart.
+     *
+     * @return array{net_total: float, vat_total: float, gross_total: float}
+     */
+    public function getTotals(): array
+    {
+        return [
+            'net_total' => $this->getTotalPrice(),
+            'vat_total' => $this->getTotalVat(),
+            'gross_total' => $this->getTotalGross(),
+        ];
+    }
+
     protected function updateItemQuantityInDatabase(int $productId, int $quantity, array $optionIds): void
     {
         $userId = Auth::id();
@@ -318,6 +332,7 @@ class CartService
                 'totalQuantity' => $items->sum('quantity'),
                 'totalPrice' => $items->sum(fn ($item) => $item['price'] * $item['quantity']),
                 'totalGross' => $items->sum(fn ($item) => $item['gross_price'] * $item['quantity']),
+                'totalVat' => $items->sum(fn ($item) => $item['gross_price'] * $item['quantity']) - $items->sum(fn ($item) => $item['price'] * $item['quantity']),
             ])
             ->toArray();
     }


### PR DESCRIPTION
## Summary
- expose VAT, gross and net totals from CartService
- include these totals in `CartController@index`
- compute VAT totals in grouped cart items
- reindex Products

## Testing
- `composer install`
- `php artisan migrate --force`
- `php artisan scout:import "App\\Models\\Product"`
- `./vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_688bc928a3e083238cfa7be220fdc9aa