### PR TITLE
Add OSS report listing resource

### DIFF
--- a/app/Filament/Resources/OSSReportResource.php
+++ b/app/Filament/Resources/OSSReportResource.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Enums\RolesEnum;
+use App\Filament\Resources\OSSReportResource\Pages;
+use App\Models\Order;
+use Filament\Facades\Filament;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables\Table;
+
+class OSSReportResource extends Resource
+{
+    protected static ?string $model = Order::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+
+    protected static ?string $navigationGroup = 'Reports';
+
+    public static function form(Form $form): Form
+    {
+        return $form;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table;
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListOSSReports::route('/'),
+        ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        $user = Filament::auth()->user();
+
+        return $user && $user->hasAnyRole([
+            RolesEnum::Admin->value,
+            RolesEnum::Vendor->value,
+        ]);
+    }
+}

--- a/app/Filament/Resources/OSSReportResource/Pages/ListOSSReports.php
+++ b/app/Filament/Resources/OSSReportResource/Pages/ListOSSReports.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Filament\Resources\OSSReportResource\Pages;
+
+use App\Enums\RolesEnum;
+use App\Filament\Resources\OSSReportResource;
+use Filament\Facades\Filament;
+use Filament\Resources\Pages\Page;
+use Illuminate\Support\Facades\Storage;
+
+class ListOSSReports extends Page
+{
+    protected static string $resource = OSSReportResource::class;
+
+    protected static string $view = 'filament.resources.oss-report-resource.pages.list-oss-reports';
+
+    public array $reports = [];
+
+    public function mount(): void
+    {
+        $user = Filament::auth()->user();
+
+        $directories = Storage::directories('exports/oss');
+        $reports = [];
+
+        foreach ($directories as $directory) {
+            $period = basename($directory);
+
+            foreach (Storage::files($directory) as $file) {
+                if (pathinfo($file, PATHINFO_EXTENSION) !== 'csv') {
+                    continue;
+                }
+
+                $vendorId = pathinfo($file, PATHINFO_FILENAME);
+
+                if ($user->hasRole(RolesEnum::Vendor->value) && (int) $vendorId !== $user->id) {
+                    continue;
+                }
+
+                $reports[] = [
+                    'period' => $period,
+                    'vendor' => $vendorId,
+                    'url' => Storage::url($file),
+                ];
+            }
+        }
+
+        $this->reports = $reports;
+    }
+}

--- a/resources/views/filament/resources/oss-report-resource/pages/list-oss-reports.blade.php
+++ b/resources/views/filament/resources/oss-report-resource/pages/list-oss-reports.blade.php
@@ -1,0 +1,30 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <h2 class="text-2xl font-bold">OSS Reports</h2>
+
+        @if(empty($reports))
+            <p>No reports available.</p>
+        @else
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead>
+                    <tr>
+                        <th class="px-4 py-2 text-left">Period</th>
+                        <th class="px-4 py-2 text-left">Vendor</th>
+                        <th class="px-4 py-2 text-left">Download</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200">
+                    @foreach($reports as $report)
+                        <tr>
+                            <td class="px-4 py-2">{{ $report['period'] }}</td>
+                            <td class="px-4 py-2">{{ $report['vendor'] }}</td>
+                            <td class="px-4 py-2">
+                                <a href="{{ $report['url'] }}" class="text-primary-600 hover:underline">Download</a>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        @endif
+    </div>
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- show generated OSS CSV exports in new Filament resource
- restrict access to admin or vendor roles

## Testing
- `php artisan test --parallel --processes=2`


------
https://chatgpt.com/codex/tasks/task_e_688fa9674864832386f34cb5ee96d789