### PR TITLE
Add product reviews integration

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -34,7 +34,9 @@ class ProductController extends Controller
 
     public function show(Product $product)
     {
-        $product->load(['reviews.user']);
+        $product->load([
+            'reviews.user:id,name',
+        ]);
 
         $hasPurchased = false;
         if (auth()->check()) {
@@ -51,7 +53,7 @@ class ProductController extends Controller
             ->get();
 
         return Inertia::render('Product/Show', [
-            'product' => new ProductResource($product),
+            'product' => ProductResource::make($product),
             'variationOptions' => request('options', []),
             'hasPurchased' => $hasPurchased,
             'relatedProducts' => ProductListResource::collection($relatedProducts),

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\ReviewResource;
 
 class ProductResource extends JsonResource
 {
@@ -13,6 +14,9 @@ class ProductResource extends JsonResource
     {
         $options = $request->input('options') ?: [];
         $images = $options ? $this->getImagesForOptions($options) : $this->getImages();
+
+        $avg = round($this->reviews()->avg('rating') ?? 0, 1);
+        $count = $this->reviews()->count();
 
         return [
             'id' => $this->id,
@@ -84,6 +88,12 @@ class ProductResource extends JsonResource
             'price_with_vat' => round((float) $this->price_with_vat, 2),
             'vat_amount' => round((float) $this->vat_amount, 2),
             'gross_price' => round((float) $this->gross_price, 2),
+
+            'average_rating' => $avg,
+            'reviews_count' => $count,
+            'reviews' => ReviewResource::collection(
+                $this->whenLoaded('reviews')
+            ),
         ];
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -234,7 +234,8 @@ class Product extends Model implements HasMedia
 
     public function reviews()
     {
-        return $this->hasMany(Review::class);
+        return $this->hasMany(Review::class)
+            ->latest();
     }
 
     // ✅ TVA calculat dinamic pe baza codului de țară

--- a/resources/js/Components/Reviews/ReviewForm.tsx
+++ b/resources/js/Components/Reviews/ReviewForm.tsx
@@ -1,0 +1,54 @@
+import { useForm } from '@inertiajs/react';
+import React from 'react';
+
+type Props = { productId: number };
+
+export default function ReviewForm({ productId }: Props) {
+  const { data, setData, post, processing, errors, reset } = useForm({
+    rating: 5 as number,
+    comment: '' as string,
+  });
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    post(route('reviews.store', productId), {
+      onSuccess: () => reset('comment'),
+    });
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <div>
+        <label className="block text-sm mb-1">Rating</label>
+        <select
+          className="select select-bordered w-full"
+          value={data.rating}
+          onChange={e => setData('rating', Number(e.target.value))}
+        >
+          {[5, 4, 3, 2, 1].map(r => (
+            <option key={r} value={r}>{r}</option>
+          ))}
+        </select>
+        {errors.rating && <p className="text-error text-sm mt-1">{errors.rating}</p>}
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Comentariu (opțional)</label>
+        <textarea
+          className="textarea textarea-bordered w-full"
+          rows={4}
+          value={data.comment}
+          onChange={e => setData('comment', e.target.value)}
+          placeholder="Spune-ne cum ți s-a părut produsul…"
+        />
+        {errors.comment && <p className="text-error text-sm mt-1">{errors.comment}</p>}
+      </div>
+
+      {(errors as any).review && <p className="text-error text-sm">{(errors as any).review}</p>}
+
+      <button className="btn btn-primary" disabled={processing}>
+        Trimite recenzia
+      </button>
+    </form>
+  );
+}

--- a/resources/js/Components/Reviews/ReviewList.tsx
+++ b/resources/js/Components/Reviews/ReviewList.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+type Review = {
+  id: number;
+  rating: number;
+  comment?: string | null;
+  user: { id: number; name: string };
+  created_at?: string;
+};
+
+export default function ReviewList({ reviews }: { reviews: Review[] }) {
+  if (!reviews?.length) return <p className="text-sm opacity-70">Încă nu există recenzii.</p>;
+
+  return (
+    <ul className="space-y-4">
+      {reviews.map(r => (
+        <li key={r.id} className="p-4 rounded-2xl border">
+          <div className="flex items-center justify-between mb-2">
+            <div className="font-medium">{r.user?.name ?? 'Utilizator'}</div>
+            <div className="text-sm">⭐ {r.rating}/5</div>
+          </div>
+          {r.comment && <p className="text-sm">{r.comment}</p>}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/resources/js/Pages/Product/Show.tsx
+++ b/resources/js/Pages/Product/Show.tsx
@@ -6,6 +6,8 @@ import ProductGallery from "@/Components/Core/Carousel";
 import CurrencyFormatter from "@/Components/Core/CurrencyFormatter";
 import {arraysAreEqual} from "@/helpers";
 import { getVatRate, calculateVatIncludedPrice, calculateVatAmount } from '@/utils/vat';
+import ReviewForm from '@/Components/Reviews/ReviewForm';
+import ReviewList from '@/Components/Reviews/ReviewList';
 
 function Show({
                 appName, product, variationOptions
@@ -240,6 +242,18 @@ function Show({
             <h2>About the Item</h2>
             <div dangerouslySetInnerHTML={{ __html: product.description }} />
           </div>
+
+          <section className="grid gap-4">
+            <h2 className="text-xl font-semibold">
+              Recenzii ({product.reviews_count}) · Medie {product.average_rating}/5
+            </h2>
+            <ReviewList reviews={product.reviews ?? []} />
+          </section>
+
+          <section className="grid gap-4">
+            <h3 className="text-lg font-medium">Lasă o recenzie</h3>
+            <ReviewForm productId={product.id} />
+          </section>
         </div>
       </div>
     </AuthenticatedLayout>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -68,6 +68,15 @@ export type Product = {
   description: string;
   meta_title: string;
   meta_description: string;
+  average_rating: number;
+  reviews_count: number;
+  reviews?: Array<{
+    id: number;
+    rating: number;
+    comment?: string | null;
+    user: { id: number; name: string };
+    created_at?: string;
+  }>;
   user: {
     id: number;
     name: string;

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\StripeController;
 use App\Http\Controllers\ShippingAddressController;
 use App\Http\Controllers\VendorController;
+use App\Http\Controllers\ReviewController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Stevebauman\Location\Facades\Location;
@@ -79,6 +80,9 @@ Route::middleware('auth')->group(function () {
         Route::get('/vendor/details', [VendorController::class, 'details'])
             ->name('vendor.details')
             ->middleware(['role:' . \App\Enums\RolesEnum::Vendor->value]);
+
+        Route::post('/products/{product}/reviews', [ReviewController::class, 'store'])
+            ->name('reviews.store');
     });
 });
 

--- a/tests/Feature/ReviewsTest.php
+++ b/tests/Feature/ReviewsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Models\Category;
+use App\Models\Department;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\User;
+
+it('allows verified buyers to post a review', function () {
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $seller = User::factory()->create();
+
+    $department = Department::forceCreate([
+        'name' => 'Dept',
+        'slug' => 'dept',
+        'active' => true,
+    ]);
+
+    $category = Category::forceCreate([
+        'name' => 'Cat',
+        'department_id' => $department->id,
+        'active' => true,
+    ]);
+
+    $product = Product::forceCreate([
+        'title' => 'Test',
+        'slug' => 'test',
+        'description' => 'desc',
+        'department_id' => $department->id,
+        'category_id' => $category->id,
+        'price' => 100,
+        'status' => 'published',
+        'quantity' => 10,
+        'created_by' => $seller->id,
+        'updated_by' => $seller->id,
+    ]);
+
+    $order = Order::forceCreate([
+        'total_price' => 100,
+        'user_id' => $user->id,
+        'vendor_user_id' => $seller->id,
+        'status' => 'paid',
+    ]);
+
+    OrderItem::forceCreate([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'price' => 100,
+        'quantity' => 1,
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('reviews.store', $product), ['rating' => 5, 'comment' => 'ok'])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('reviews', [
+        'user_id' => $user->id,
+        'product_id' => $product->id,
+        'rating' => 5,
+    ]);
+});


### PR DESCRIPTION
## Summary
- enable posting product reviews with buyer-only validation
- expose review data on product show and API resource
- add frontend components for listing and submitting reviews

## Testing
- `npm run build` (fails: Property 'cif' does not exist...)
- `php artisan test` *(fails: require(/workspace/marketplace/vendor/autoload.php): Failed to open stream)*


------
https://chatgpt.com/codex/tasks/task_e_689878466dd483239a6c0e50ab92a404