### PR TITLE
Add product review routes and frontend integration

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -34,7 +34,9 @@ class ProductController extends Controller
 
     public function show(Product $product)
     {
-        $product->load(['reviews.user']);
+        $product->load([
+            'reviews.user:id,name',
+        ]);
 
         $hasPurchased = false;
         if (auth()->check()) {

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -2,35 +2,59 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Order;
+use App\Enums\OrderStatusEnum;
+use App\Http\Resources\ReviewResource;
+use App\Models\OrderItem;
 use App\Models\Product;
 use App\Models\Review;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class ReviewController extends Controller
 {
     public function store(Request $request, Product $product)
     {
-        $request->validate([
-            'rating' => 'required|integer|min:1|max:5',
-            'comment' => 'nullable|string',
+        $user = $request->user();
+
+        $data = $request->validate([
+            'rating' => ['required', 'integer', Rule::in([1, 2, 3, 4, 5])],
+            'comment' => ['nullable', 'string', 'max:2000'],
         ]);
 
-        $hasPurchased = Order::where('user_id', auth()->id())
-            ->whereHas('orderItems', fn ($q) => $q->where('product_id', $product->id))
-            ->exists();
-
-        if (! $hasPurchased || ! auth()->user()->hasVerifiedEmail()) {
-            abort(403, 'Only verified buyers can leave a review.');
+        if (! $user->hasVerifiedEmail()) {
+            return back()->withErrors(['review' => 'Trebuie să ai emailul verificat.']);
         }
 
-        Review::create([
-            'user_id' => auth()->id(),
+        $hasPurchased = OrderItem::query()
+            ->where('product_id', $product->id)
+            ->whereHas('order', function ($q) use ($user) {
+                $q->where('user_id', $user->id)
+                    ->whereIn('status', [OrderStatusEnum::Paid->value, OrderStatusEnum::Delivered->value]);
+            })
+            ->exists();
+
+        if (! $hasPurchased) {
+            return back()->withErrors(['review' => 'Doar cumpărătorii pot lăsa recenzii.']);
+        }
+
+        $already = Review::query()
+            ->where('user_id', $user->id)
+            ->where('product_id', $product->id)
+            ->exists();
+
+        if ($already) {
+            return back()->withErrors(['review' => 'Ai trimis deja o recenzie pentru acest produs.']);
+        }
+
+        $review = Review::create([
+            'user_id' => $user->id,
             'product_id' => $product->id,
-            'rating' => $request->rating,
-            'comment' => $request->comment,
+            'rating' => $data['rating'],
+            'comment' => $data['comment'] ?? null,
         ]);
 
-        return redirect()->back();
+        return back()
+            ->with('success', 'Mulțumim pentru recenzie!')
+            ->with('newReview', ReviewResource::make($review));
     }
 }

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -14,6 +14,9 @@ class ProductResource extends JsonResource
         $options = $request->input('options') ?: [];
         $images = $options ? $this->getImagesForOptions($options) : $this->getImages();
 
+        $avg = round($this->reviews()->avg('rating') ?? 0, 1);
+        $count = $this->reviews()->count();
+
         return [
             'id' => $this->id,
             'title' => $this->title,
@@ -84,6 +87,11 @@ class ProductResource extends JsonResource
             'price_with_vat' => round((float) $this->price_with_vat, 2),
             'vat_amount' => round((float) $this->vat_amount, 2),
             'gross_price' => round((float) $this->gross_price, 2),
+            'average_rating' => $avg,
+            'reviews_count' => $count,
+            'reviews' => ReviewResource::collection(
+                $this->whenLoaded('reviews')
+            ),
         ];
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -234,7 +234,8 @@ class Product extends Model implements HasMedia
 
     public function reviews()
     {
-        return $this->hasMany(Review::class);
+        return $this->hasMany(Review::class)
+            ->latest();
     }
 
     // ✅ TVA calculat dinamic pe baza codului de țară

--- a/resources/js/Components/Reviews/ReviewForm.tsx
+++ b/resources/js/Components/Reviews/ReviewForm.tsx
@@ -1,0 +1,64 @@
+import { useForm } from '@inertiajs/react';
+import React from 'react';
+
+interface Props {
+  productId: number;
+}
+
+export default function ReviewForm({ productId }: Props) {
+  const { data, setData, post, processing, errors, reset } = useForm({
+    rating: 5 as number,
+    comment: '' as string,
+  });
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    post(route('reviews.store', productId), {
+      onSuccess: () => reset('comment'),
+    });
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <div>
+        <label className="block text-sm mb-1">Rating</label>
+        <select
+          className="select select-bordered w-full"
+          value={data.rating}
+          onChange={(e) => setData('rating', Number(e.target.value))}
+        >
+          {[5, 4, 3, 2, 1].map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+        {errors.rating && (
+          <p className="text-error text-sm mt-1">{errors.rating}</p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Comentariu (opțional)</label>
+        <textarea
+          className="textarea textarea-bordered w-full"
+          rows={4}
+          value={data.comment}
+          onChange={(e) => setData('comment', e.target.value)}
+          placeholder="Spune-ne cum ți s-a părut produsul…"
+        />
+        {errors.comment && (
+          <p className="text-error text-sm mt-1">{errors.comment}</p>
+        )}
+      </div>
+
+      {(errors as any).review && (
+        <p className="text-error text-sm">{(errors as any).review}</p>
+      )}
+
+      <button className="btn btn-primary" disabled={processing}>
+        Trimite recenzia
+      </button>
+    </form>
+  );
+}

--- a/resources/js/Components/Reviews/ReviewList.tsx
+++ b/resources/js/Components/Reviews/ReviewList.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface Review {
+  id: number;
+  rating: number;
+  comment?: string | null;
+  user: { id: number; name: string };
+  created_at?: string;
+}
+
+export default function ReviewList({ reviews }: { reviews: Review[] }) {
+  if (!reviews?.length) {
+    return <p className="text-sm opacity-70">Încă nu există recenzii.</p>;
+  }
+
+  return (
+    <ul className="space-y-4">
+      {reviews.map((r) => (
+        <li key={r.id} className="p-4 rounded-2xl border">
+          <div className="flex items-center justify-between mb-2">
+            <div className="font-medium">{r.user?.name ?? 'Utilizator'}</div>
+            <div className="text-sm">⭐ {r.rating}/5</div>
+          </div>
+          {r.comment && <p className="text-sm">{r.comment}</p>}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/resources/js/Pages/Product/Show.tsx
+++ b/resources/js/Pages/Product/Show.tsx
@@ -6,6 +6,9 @@ import ProductGallery from "@/Components/Core/Carousel";
 import CurrencyFormatter from "@/Components/Core/CurrencyFormatter";
 import {arraysAreEqual} from "@/helpers";
 import { getVatRate, calculateVatIncludedPrice, calculateVatAmount } from '@/utils/vat';
+import ReviewForm from '@/Components/Reviews/ReviewForm';
+import ReviewList from '@/Components/Reviews/ReviewList';
+import StarRating from '@/Components/Core/StarRating';
 
 function Show({
                 appName, product, variationOptions
@@ -35,7 +38,7 @@ function Show({
     return [...product.images];
   }, [product, selectedOptions]);
 
-  const { countryCode } = usePage<PageProps>().props as PageProps;
+  const { countryCode, auth } = usePage<PageProps>().props as PageProps;
 
   const computedProduct = useMemo(() => {
     const selectedOptionIds = Object.values(selectedOptions)
@@ -221,6 +224,10 @@ function Show({
             <ProductGallery images={images} />
             <div>
               <h1 className="text-2xl font-bold">{product.title}</h1>
+              <div className="mt-2 flex items-center gap-2">
+                <StarRating rating={product.average_rating} />
+                <span className="text-sm text-gray-600">({product.reviews_count})</span>
+              </div>
               <p className="text-gray-600">
                 {product.user.name} in {product.department.name}
               </p>
@@ -240,6 +247,20 @@ function Show({
             <h2>About the Item</h2>
             <div dangerouslySetInnerHTML={{ __html: product.description }} />
           </div>
+
+          <section className="grid gap-4">
+            <h2 className="text-xl font-semibold">
+              Recenzii ({product.reviews_count}) · Medie {product.average_rating}/5
+            </h2>
+            <ReviewList reviews={product.reviews ?? []} />
+          </section>
+
+          {(auth as any).user && (
+            <section className="grid gap-4">
+              <h3 className="text-lg font-medium">Lasă o recenzie</h3>
+              <ReviewForm productId={product.id} />
+            </section>
+          )}
         </div>
       </div>
     </AuthenticatedLayout>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -34,6 +34,14 @@ export type Image = {
   large: string;
 };
 
+export type Review = {
+  id: number;
+  rating: number;
+  comment?: string | null;
+  user: { id: number; name: string };
+  created_at?: string;
+};
+
 export type VariationTypeOption = {
   id: number;
   name: string;
@@ -85,6 +93,9 @@ export type Product = {
     quantity: number;
     price: number;
   }>
+  average_rating?: number;
+  reviews_count?: number;
+  reviews?: Review[];
 }
 
 export type ProductListItem = {

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\StripeController;
 use App\Http\Controllers\ShippingAddressController;
 use App\Http\Controllers\VendorController;
+use App\Http\Controllers\ReviewController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Stevebauman\Location\Facades\Location;
@@ -79,6 +80,9 @@ Route::middleware('auth')->group(function () {
         Route::get('/vendor/details', [VendorController::class, 'details'])
             ->name('vendor.details')
             ->middleware(['role:' . \App\Enums\RolesEnum::Vendor->value]);
+
+        Route::post('/products/{product}/reviews', [ReviewController::class, 'store'])
+            ->name('reviews.store');
     });
 });
 

--- a/tests/Feature/ReviewsTest.php
+++ b/tests/Feature/ReviewsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Enums\OrderStatusEnum;
+use App\Enums\ProductStatusEnum;
+use App\Models\Category;
+use App\Models\Department;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+it('allows verified buyers to post a review', function () {
+    $buyer = User::factory()->create(['email_verified_at' => now()]);
+    $vendor = User::factory()->create();
+
+    $department = new Department();
+    $department->name = 'Dept';
+    $department->slug = 'dept';
+    $department->save();
+
+    $category = new Category();
+    $category->name = 'Cat';
+    $category->department_id = $department->id;
+    $category->active = true;
+    $category->save();
+
+    $product = new Product();
+    $product->title = 'Test';
+    $product->slug = 'test';
+    $product->description = 'desc';
+    $product->department_id = $department->id;
+    $product->category_id = $category->id;
+    $product->price = 100;
+    $product->status = ProductStatusEnum::Published->value;
+    $product->quantity = 10;
+    $product->created_by = $vendor->id;
+    $product->updated_by = $vendor->id;
+    $product->save();
+
+    $order = Order::create([
+        'total_price' => 100,
+        'user_id' => $buyer->id,
+        'vendor_user_id' => $vendor->id,
+        'status' => OrderStatusEnum::Paid->value,
+    ]);
+
+    OrderItem::create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'quantity' => 1,
+        'net_price' => 100,
+        'vat_rate' => 0,
+        'vat_amount' => 0,
+        'gross_price' => 100,
+        'variation_type_option_ids' => [],
+    ]);
+
+    $this->actingAs($buyer)
+        ->post(route('reviews.store', $product), ['rating' => 5, 'comment' => 'ok'])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect();
+
+    expect(DB::table('reviews')->where('user_id', $buyer->id)->where('product_id', $product->id)->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- add authenticated route and controller logic to create product reviews
- expose average ratings and review data in product API responses
- build React components and UI sections for listing and submitting reviews

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `npm run build` *(fails: TS2339: Property 'cif' does not exist on type...)*

------
https://chatgpt.com/codex/tasks/task_e_6898783e9f7083238074de03b6dde576