### PR TITLE
Exempt Stripe webhook from CSRF verification

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+
+class VerifyCsrfToken extends Middleware
+{
+    /**
+     * The URIs that should be excluded from CSRF verification.
+     *
+     * @var array<int, string>
+     */
+    protected $except = [
+        '/stripe/webhook',
+    ];
+}
+


### PR DESCRIPTION
## Summary
- add VerifyCsrfToken middleware
- exempt `/stripe/webhook` from CSRF check to avoid 419 responses

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f552fdb883238bc77aaf93ac5f0a