### PR TITLE
Add Stripe tax rates for RO, BG, and HU

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -192,6 +192,9 @@ class CartController extends Controller
 
                     $calc = $vatRateService->calculate($cartItem['price'], $cartItem['vat_rate_type'], $vatCountry);
 
+                    $taxRates = config('app.stripe_tax_rates');
+                    $stripeTaxRate = $taxRates[$vatCountry] ?? null;
+
                     OrderItem::create([
                         'order_id' => $order->id,
                         'product_id' => $cartItem['product_id'],
@@ -219,9 +222,13 @@ class CartController extends Controller
                                 'images' => [$cartItem['image']],
                             ],
                             'unit_amount' => (int) round($calc['gross'] * 100),
+                            'tax_behavior' => 'inclusive',
                         ],
                         'quantity' => $cartItem['quantity'],
                     ];
+                    if ($stripeTaxRate) {
+                        $lineItem['tax_rates'] = [$stripeTaxRate];
+                    }
                     if ($description) {
                         $lineItem['price_data']['product_data']['description'] = $description;
                     }

--- a/config/app.php
+++ b/config/app.php
@@ -128,6 +128,12 @@ return [
     'stripe_secret_key' => env('STRIPE_SECRET'),
     'stripe_webhook_secret' => env('STRIPE_WEBHOOK_SECRET'),
 
+    'stripe_tax_rates' => [
+        'RO' => env('STRIPE_TAX_RATE_RO'),
+        'BG' => env('STRIPE_TAX_RATE_BG'),
+        'HU' => env('STRIPE_TAX_RATE_HU'),
+    ],
+
     'platform_fee_pct' => 10
 ];
 

--- a/database/seeders/StripeTaxRateSeeder.php
+++ b/database/seeders/StripeTaxRateSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class StripeTaxRateSeeder extends Seeder
+{
+    /**
+     * Create Stripe TaxRate objects for supported countries.
+     */
+    public function run(): void
+    {
+        \Stripe\Stripe::setApiKey(config('app.stripe_secret_key'));
+
+        $rates = [
+            [
+                'display_name' => 'VAT',
+                'jurisdiction' => 'RO',
+                'percentage' => 19,
+                'inclusive' => true,
+            ],
+            [
+                'display_name' => 'VAT',
+                'jurisdiction' => 'BG',
+                'percentage' => 20,
+                'inclusive' => true,
+            ],
+            [
+                'display_name' => 'VAT',
+                'jurisdiction' => 'HU',
+                'percentage' => 27,
+                'inclusive' => true,
+            ],
+        ];
+
+        foreach ($rates as $rate) {
+            \Stripe\TaxRate::create($rate);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- seed Stripe TaxRate objects for Romania, Bulgaria, and Hungary
- include Stripe tax rate references in cart checkout line items
- configure Stripe tax rate IDs in app config

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/marketplace/vendor/autoload.php')*
- `composer install` *(fails: requires GitHub token to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f859e6148323a4f4687c2ce4f841