### PR TITLE
Handle Stripe success with session storage

### DIFF
--- a/tests/Feature/StripeSuccessTest.php
+++ b/tests/Feature/StripeSuccessTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Enums\OrderStatusEnum;
+use App\Models\Order;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+it('shows summary from session when session_id is missing', function () {
+    $user = User::factory()->create();
+    $vendor = User::factory()->create();
+
+    $order = Order::create([
+        'total_price' => 100,
+        'user_id' => $user->id,
+        'vendor_user_id' => $vendor->id,
+        'status' => OrderStatusEnum::Paid->value,
+        'net_total' => 80,
+        'vat_total' => 20,
+    ]);
+
+    $response = $this->actingAs($user)
+        ->withSession(['stripe_order_ids' => [$order->id]])
+        ->get(route('stripe.success'));
+
+    $response->assertStatus(200);
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('Stripe/Success')
+        ->where('orders.0.id', $order->id)
+        ->where('sessionTotals.total', 100)
+        ->where('sessionTotals.subtotal', 80)
+        ->where('sessionTotals.tax', 20)
+    );
+});
+


### PR DESCRIPTION
## Summary
- Retrieve order summary from session when `session_id` missing
- Persist order IDs in session and redirect to success route
- Cover session-based Stripe success flow with feature test

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a6f86a7a54832384372d34648d9b80