### PR TITLE
Log OSS transactions and add OSS export test

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -8,6 +8,7 @@ use App\Models\Address;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\Product;
+use App\Models\OssTransaction;
 use App\Models\Vendor;
 use App\Services\CartService;
 use App\Services\TransactionClassifierService;
@@ -233,6 +234,20 @@ class CartController extends Controller
                     'net_total' => $orderNet,
                     'vat_total' => $orderVat,
                 ]);
+
+                if ($transactionType === 'OSS') {
+                    $vatRate = $orderNet > 0 ? round($orderVat / $orderNet * 100, 2) : 0;
+
+                    OssTransaction::create([
+                        'vendor_id' => $vendor->user_id,
+                        'order_id' => $order->id,
+                        'client_country_code' => $clientCountryCode,
+                        'vat_rate' => $vatRate,
+                        'net_amount' => $orderNet,
+                        'vat_amount' => $orderVat,
+                        'gross_amount' => $orderGross,
+                    ]);
+                }
             }
             $firstOrder = $orders[0];
             $vendorStripeAccountId = $firstOrder->vendorUser->getStripeAccountId();

--- a/tests/Feature/ExportOssReportTest.php
+++ b/tests/Feature/ExportOssReportTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Enums\OrderStatusEnum;
+use App\Enums\VendorStatusEnum;
+use App\Models\Order;
+use App\Models\OssTransaction;
+use App\Models\User;
+use App\Models\Vendor;
+use Illuminate\Support\Facades\Storage;
+
+it('exports oss report when transactions exist', function () {
+    Storage::fake('public');
+
+    $vendorUser = User::factory()->create(['country_code' => 'RO']);
+
+    $vendor = Vendor::create([
+        'user_id' => $vendorUser->id,
+        'status' => VendorStatusEnum::Approved->value,
+        'store_name' => 'Vendor',
+        'country_code' => 'RO',
+    ]);
+
+    $client = User::factory()->create(['country_code' => 'DE']);
+
+    $order = Order::create([
+        'stripe_session_id' => 'sess_1',
+        'user_id' => $client->id,
+        'vendor_user_id' => $vendorUser->id,
+        'total_price' => 119,
+        'net_total' => 100,
+        'vat_total' => 19,
+        'vat_country_code' => 'DE',
+        'transaction_type' => 'OSS',
+        'status' => OrderStatusEnum::Draft->value,
+    ]);
+
+    OssTransaction::create([
+        'vendor_id' => $vendor->user_id,
+        'order_id' => $order->id,
+        'client_country_code' => 'DE',
+        'vat_rate' => 19,
+        'net_amount' => 100,
+        'vat_amount' => 19,
+        'gross_amount' => 119,
+    ]);
+
+    $month = now()->format('Y-m');
+
+    $this->artisan('export:oss-report', ['--month' => $month])
+        ->expectsOutput('OSS report exported successfully.')
+        ->assertExitCode(0);
+
+    Storage::disk('public')->assertExists("exports/oss/{$month}/{$vendor->user_id}.csv");
+});
+


### PR DESCRIPTION
## Summary
- record OSS transactions after checkout in `CartController`
- add feature test ensuring `export:oss-report` generates files when transactions exist

## Testing
- ⚠️ `composer install` *(failed: curl error 56 - CONNECT tunnel failed, response 403)*
- ⚠️ `php artisan test` *(failed: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f87718b0832384544b02531f2164