### PR TITLE
Handle missing Stripe tax rate configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ APP_URL=http://localhost:8000
 ...
 ```
 
+##### Stripe tax rate IDs
+
+Stripe tax rates for each supported country must be configured:
+
+```env
+STRIPE_TAX_RATE_RO=txr_...
+STRIPE_TAX_RATE_BG=txr_...
+STRIPE_TAX_RATE_HU=txr_...
+```
+
 #### 7. Run Migrations
 
 ```bash

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -195,6 +195,9 @@ class CartController extends Controller
 
                     $taxRates = config('app.stripe_tax_rates');
                     $stripeTaxRate = $taxRates[$vatCountry] ?? null;
+                    if (! $stripeTaxRate) {
+                        throw new \RuntimeException("Missing Stripe tax rate ID for {$vatCountry}");
+                    }
 
                     OrderItem::create([
                         'order_id' => $order->id,
@@ -226,10 +229,8 @@ class CartController extends Controller
                             'tax_behavior' => 'inclusive',
                         ],
                         'quantity' => $cartItem['quantity'],
+                        'tax_rates' => [$stripeTaxRate],
                     ];
-                    if ($stripeTaxRate) {
-                        $lineItem['tax_rates'] = [$stripeTaxRate];
-                    }
                     if ($description) {
                         $lineItem['price_data']['product_data']['description'] = $description;
                     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Services\CartService;
 use Illuminate\Support\Facades\Schedule;
 use Illuminate\Support\Facades\Vite;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use Torann\GeoIP\Facades\GeoIP;
 
@@ -58,5 +59,14 @@ class AppServiceProvider extends ServiceProvider
 
         // ⚡ Optimizare vite
         Vite::prefetch(concurrency: 3);
+
+        $taxRates = config('app.stripe_tax_rates', []);
+        $missingRates = collect($taxRates)
+            ->filter(fn ($value) => empty($value))
+            ->keys();
+
+        if ($missingRates->isNotEmpty()) {
+            Log::warning('Stripe tax rate IDs missing for countries: ' . $missingRates->implode(', '));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- throw when Stripe tax rate ID for VAT country is missing during checkout
- warn at boot if Stripe tax rate IDs are not configured
- document required Stripe tax rate env vars

## Testing
- `composer install` *(fails: needs GitHub token)*
- `vendor/bin/pest` *(fails: vendor/bin/pest: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a705c77dc48323ae36050fc48e2052