### PR TITLE
Expose VAT fields in API and drop client VAT math

### DIFF
--- a/app/Http/Resources/ProductListResource.php
+++ b/app/Http/Resources/ProductListResource.php
@@ -41,6 +41,7 @@ class ProductListResource extends JsonResource
             'vat'                => $vatFormatted,
             'gross'              => $grossFormatted,
             'gross_price'        => $vatResult['gross'], // ✅ important pentru React
+            'vat_amount'         => $vatResult['vat'],
             'net_price'          => round($net, 2),
             'vat_rate_type'      => $this->vat_rate_type ?? 'standard_rate',
             'country_code'       => session('country_code', 'RO'),

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Services\VatRateService;
 
 class ProductResource extends JsonResource
 {
@@ -68,11 +69,14 @@ class ProductResource extends JsonResource
                 ];
             }),
             'variations' => $this->variations->map(function ($variation) {
+                $calc = app(VatRateService::class)->calculate($variation->price, $this->vat_rate_type);
                 return [
                     'id' => $variation->id,
                     'variation_type_option_ids' => $variation->variation_type_option_ids,
                     'quantity' => $variation->quantity,
                     'price' => $variation->price,
+                    'gross_price' => $calc['gross'],
+                    'vat_amount' => $calc['vat'],
                 ];
             }),
 

--- a/app/Services/CartService.php
+++ b/app/Services/CartService.php
@@ -102,6 +102,7 @@ class CartService
                         ];
                     }
 
+                    $calc = app(\App\Services\VatRateService::class)->calculate($cartItem['price'], $product->vat_rate_type);
                     $cartItemData[] = [
                         'id' => $cartItem['id'],
                         'product_id' => $product->id,
@@ -109,7 +110,8 @@ class CartService
                         'slug' => $product->slug,
                         'price' => $cartItem['price'],
                         'vat_rate_type' => $product->vat_rate_type ?? 'standard_rate',
-                        'gross_price' => app(\App\Services\VatRateService::class)->calculate($cartItem['price'], $product->vat_rate_type)['gross'],
+                        'gross_price' => $calc['gross'],
+                        'vat_amount' => $calc['vat'],
                         'quantity' => $cartItem['quantity'],
                         'option_ids' => $cartItem['option_ids'],
                         'options' => $optionInfo,
@@ -167,7 +169,12 @@ class CartService
 
     public function getTotalVat(): float
     {
-        return $this->getTotalGross() - $this->getTotalPrice();
+        $total = 0;
+        foreach ($this->getCartItems() as $item) {
+            $total += $item['quantity'] * ($item['vat_amount'] ?? ($item['gross_price'] - $item['price']));
+        }
+
+        return $total;
     }
 
     /**

--- a/resources/js/Components/App/CartItem.tsx
+++ b/resources/js/Components/App/CartItem.tsx
@@ -13,7 +13,7 @@ function CartItem({item}: { item: CartItemType }) {
   const [quantity, setQuantity] = useState(item.quantity)
   const [error, setError] = useState('')
   const grossPrice = item.gross_price
-  const vatAmount = grossPrice - item.price
+  const vatAmount = item.vat_amount
 
   const onDeleteClick = () => {
     deleteForm.delete(route('cart.destroy', item.product_id), {

--- a/resources/js/Components/App/ProductItem.tsx
+++ b/resources/js/Components/App/ProductItem.tsx
@@ -1,10 +1,8 @@
-import { ProductListItem, VatRateType } from "@/types";
+import { ProductListItem } from "@/types";
 import { Link, useForm } from "@inertiajs/react";
 import CurrencyFormatter from "@/Components/Core/CurrencyFormatter";
-import vatService from '@/services/vatService';
-import { useVatRate } from '@/hooks/useVatRate';
 
-export default function ProductItem({ product, countryCode }: { product: ProductListItem; countryCode: string }) {
+export default function ProductItem({ product }: { product: ProductListItem }) {
   const form = useForm<{
     option_ids: Record<string, number>;
     quantity: number;
@@ -24,11 +22,7 @@ export default function ProductItem({ product, countryCode }: { product: Product
     });
   };
 
-  const rate = useVatRate(countryCode, (product.vat_rate_type as VatRateType) ?? 'standard_rate');
-  const displayPrice = product.gross_price ?? vatService.calculateVatIncludedPrice(
-    product.net_price ?? product.price,
-    rate
-  );
+  const displayPrice = product.gross_price;
 
   return (
     <div className="card bg-base-100 shadow">

--- a/resources/js/Components/App/ProductListing.tsx
+++ b/resources/js/Components/App/ProductListing.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import ProductItem from "@/Components/App/ProductItem";
-import {Link, usePage} from "@inertiajs/react";
-import {PaginationProps, ProductListItem, PageProps} from "@/types";
+import {Link} from "@inertiajs/react";
+import {PaginationProps, ProductListItem} from "@/types";
 
 function ProductListing({products}: { products: PaginationProps<ProductListItem> }) {
-  const { countryCode } = usePage<PageProps>().props as PageProps;
   return (
     <div className="container py-8 px-4 mx-auto">
       {products.data.length === 0 && (
@@ -14,7 +13,7 @@ function ProductListing({products}: { products: PaginationProps<ProductListItem>
       )}
       <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
         {products.data.map(product => (
-          <ProductItem product={product} key={product.id} countryCode={countryCode}/>
+          <ProductItem product={product} key={product.id} />
         ))}
       </div>
       {/*<pre>{JSON.stringify(products, undefined, 2)}</pre>*/}

--- a/resources/js/Pages/Home.tsx
+++ b/resources/js/Pages/Home.tsx
@@ -10,10 +10,9 @@ import {
 import ProductItem from "@/Components/App/ProductItem";
 import FilterPanel from "@/Components/App/FilterPanel";
 import NumberFormatter from "@/Components/Core/NumberFormatter";
-import ProductListing from "@/Components/App/ProductListing";
 import BannerSlider from "@/Components/App/BannerSlider";
 
-function CustomHits({ countryCode }: { countryCode: string }) {
+function CustomHits() {
   const { hits, results } = useHits();
 
   if (!results || results.nbHits === 0) {
@@ -57,7 +56,7 @@ function CustomHits({ countryCode }: { countryCode: string }) {
       </div>
       <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
         {hits.map((hit: any) => (
-          <ProductItem product={hit} key={hit.id} countryCode={countryCode} />
+          <ProductItem product={hit} key={hit.id} />
         ))}
       </div>
     </>
@@ -92,9 +91,8 @@ const sampleBanners = [
 ];
 
 export default function Home({
-                               products,
-                               countryCode
-                             }: PageProps<{ products: PaginationProps<Product>; countryCode: string }>) {
+                               products: _products
+                             }: PageProps<{ products: PaginationProps<Product> }>) {
 
   return (
     <AuthenticatedLayout>
@@ -107,7 +105,7 @@ export default function Home({
 
           <div className="flex-1">
             <Configure hitsPerPage={24} />
-            <CustomHits countryCode={countryCode} />
+            <CustomHits />
             <Pagination
               classNames={{
                 root: 'hidden justify-center md:flex',

--- a/resources/js/Pages/Product/Show.tsx
+++ b/resources/js/Pages/Product/Show.tsx
@@ -5,8 +5,7 @@ import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
 import ProductGallery from "@/Components/Core/Carousel";
 import CurrencyFormatter from "@/Components/Core/CurrencyFormatter";
 import {arraysAreEqual} from "@/helpers";
-import vatService from '@/services/vatService';
-import { useVatRate } from '@/hooks/useVatRate';
+ 
 
 function Show({
                 appName, product, variationOptions
@@ -36,35 +35,26 @@ function Show({
     return [...product.images];
   }, [product, selectedOptions]);
 
-  const { countryCode } = usePage<PageProps>().props as PageProps;
-
-  const rate = useVatRate(countryCode, (product.vat_rate_type as any) ?? 'standard_rate');
-
   const computedProduct = useMemo(() => {
     const selectedOptionIds = Object.values(selectedOptions)
       .map(op => op.id)
       .sort();
 
     let price = product.price;
+    let gross_price = product.gross_price;
+    let vat_amount = product.vat_amount;
     let quantity = product.quantity === null ? Number.MAX_VALUE : product.quantity;
 
     for (let variation of product.variations) {
       const optionIds = variation.variation_type_option_ids.sort();
       if (arraysAreEqual(selectedOptionIds, optionIds)) {
         price = variation.price;
+        gross_price = variation.gross_price;
+        vat_amount = variation.vat_amount;
         quantity = variation.quantity === null ? Number.MAX_VALUE : variation.quantity;
         break;
       }
     }
-
-    const gross_price =
-      price === product.price && product.gross_price !== undefined
-        ? product.gross_price
-        : vatService.calculateVatIncludedPrice(price, rate);
-    const vat_amount =
-      price === product.price && product.gross_price !== undefined
-        ? product.gross_price - price
-        : vatService.calculateVatAmount(price, rate);
     return {
       price,
       gross_price,
@@ -72,7 +62,7 @@ function Show({
       vat_rate_type: product.vat_rate_type,
       quantity,
     };
-  }, [product, selectedOptions, countryCode, rate]);
+  }, [product, selectedOptions]);
 
   useEffect(() => {
     for (let type of product.variationTypes) {

--- a/resources/js/services/vatService.ts
+++ b/resources/js/services/vatService.ts
@@ -21,12 +21,4 @@ async function getRate(
   return rate;
 }
 
-function calculateVatIncludedPrice(net: number, rate: number): number {
-  return +(net * (1 + rate / 100)).toFixed(2);
-}
-
-function calculateVatAmount(net: number, rate: number): number {
-  return +(net * (rate / 100)).toFixed(2);
-}
-
-export default { getRate, calculateVatIncludedPrice, calculateVatAmount };
+export default { getRate };

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -61,7 +61,7 @@ export type Product = {
   vat_rate_type?: string;
   net_price?: number;
   gross_price: number;
-  vat_amount?: number;
+  vat_amount: number;
   image: string;
   images: Image[];
   short_description: string;
@@ -84,6 +84,8 @@ export type Product = {
     variation_type_option_ids: number[];
     quantity: number;
     price: number;
+    gross_price: number;
+    vat_amount: number;
   }>
 }
 
@@ -95,6 +97,7 @@ export type ProductListItem = {
   net_price: number;
   vat_rate_type: string;
   gross_price: number;
+  vat_amount: number;
   quantity: number;
   image: string;
   user_id: number;
@@ -113,6 +116,7 @@ export type CartItem = {
   price: number;
   vat_rate_type: string;
   gross_price: number;
+  vat_amount: number;
   quantity: number;
   image: string;
   option_ids: Record<string, number>;


### PR DESCRIPTION
## Summary
- include `gross_price` and `vat_amount` in product variations, listings, and cart items
- use API-provided `gross_price`/`vat_amount` instead of client VAT calculations
- remove VAT math utilities and rely on server data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Property 'cif' does not exist...)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a705cc1ae08323965a4ea558b56ef3