### PR TITLE
Schedule OSS report and email vendors

### DIFF
--- a/app/Console/Commands/ExportOssReport.php
+++ b/app/Console/Commands/ExportOssReport.php
@@ -3,6 +3,8 @@
 namespace App\Console\Commands;
 
 use App\Models\OssTransaction;
+use App\Models\Vendor;
+use App\Notifications\OssReportGenerated;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
 
@@ -49,6 +51,12 @@ class ExportOssReport extends Command
 
             $fileName = "exports/oss/{$month}/{$vendorId}.csv";
             Storage::disk('public')->put($fileName, $csvData);
+
+            $vendor = Vendor::with('user')->find($vendorId);
+
+            if ($vendor && $vendor->user) {
+                $vendor->user->notify(new OssReportGenerated($month));
+            }
         }
 
         $this->info('OSS report exported successfully.');

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,7 +24,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        $schedule->command('export:oss-report')->monthlyOn(1, '01:00');
+        $schedule->command('export:oss-report')->monthly();
     }
 
     /**

--- a/app/Notifications/OssReportGenerated.php
+++ b/app/Notifications/OssReportGenerated.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class OssReportGenerated extends Notification
+{
+    use Queueable;
+
+    public function __construct(protected string $month)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('OSS Report Generated')
+            ->line("Your OSS report for {$this->month} has been generated.")
+            ->line('Thank you for using our platform!');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'month' => $this->month,
+        ];
+    }
+}

--- a/tests/Feature/ExportOssReportTest.php
+++ b/tests/Feature/ExportOssReportTest.php
@@ -6,10 +6,13 @@ use App\Models\Order;
 use App\Models\OssTransaction;
 use App\Models\User;
 use App\Models\Vendor;
+use App\Notifications\OssReportGenerated;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
 
 it('exports oss report when transactions exist', function () {
     Storage::fake('public');
+    Notification::fake();
 
     $vendorUser = User::factory()->create(['country_code' => 'RO']);
 
@@ -51,5 +54,6 @@ it('exports oss report when transactions exist', function () {
         ->assertExitCode(0);
 
     Storage::disk('public')->assertExists("exports/oss/{$month}/{$vendor->user_id}.csv");
+    Notification::assertSentTo($vendorUser, OssReportGenerated::class);
 });
 


### PR DESCRIPTION
## Summary
- schedule `export:oss-report` to run monthly
- email vendors when their OSS report is generated

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install --no-interaction` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a705cff3748323877a6be225ef030b