### PR TITLE
Add refund button with role checks on order pages

### DIFF
--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -39,11 +39,13 @@ class OrderController extends Controller
 
         $order->load([
             'orderItems.product',
-            'shippingAddress.country'
+            'shippingAddress.country',
+            'vendorUser'
         ]);
 
         return Inertia::render('Orders/Show', [
             'order' => new OrderResource($order),
+            'canRefund' => auth()->user()->isAdmin() || $order->vendor_user_id === auth()->id(),
         ]);
     }
 

--- a/resources/js/Pages/Orders/Show.tsx
+++ b/resources/js/Pages/Orders/Show.tsx
@@ -79,7 +79,7 @@ const getStatusBadgeClass = (status: string): string => {
   }
 };
 
-export default function Show({ order }: { order: Order }) {
+export default function Show({ order, canRefund }: { order: Order, canRefund: boolean }) {
   // Calculate subtotal
   const subtotal = (order.orderItems || []).reduce(
     (acc, item) => acc + item.net_price * item.quantity,
@@ -113,6 +113,16 @@ export default function Show({ order }: { order: Order }) {
             >
               Print Invoice
             </Link>
+            {canRefund && (
+              <Link
+                href={`/orders/${order.id}/refund`}
+                method="post"
+                as="button"
+                className="btn btn-error"
+              >
+                Refund Order
+              </Link>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- display refund button on order details when admin or vendor can refund
- expose server-side flag `canRefund` for order details

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a705d7ce7c83238f916d03f7fd837f