### PR TITLE
Ensure forWebsite scope returns products correctly

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -51,7 +51,8 @@ class Product extends Model implements HasMedia
     public function scopeVendorApproved(Builder $query)
     {
         return $query->join('vendors', 'vendors.user_id', '=', 'products.created_by')
-            ->where('vendors.status', VendorStatusEnum::Approved->value);
+            ->where('vendors.status', VendorStatusEnum::Approved->value)
+            ->select('products.*');
     }
 
     public function user(): BelongsTo

--- a/tests/Feature/ProductForWebsiteScopeTest.php
+++ b/tests/Feature/ProductForWebsiteScopeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Enums\ProductStatusEnum;
+use App\Enums\VendorStatusEnum;
+use App\Models\Category;
+use App\Models\Department;
+use App\Models\Product;
+use App\Models\User;
+use App\Models\Vendor;
+
+it('returns products with the correct id when using the forWebsite scope', function () {
+    // Ensure vendor user id differs from product id
+    User::factory()->create();
+
+    $vendorUser = User::factory()->create();
+    Vendor::create([
+        'user_id' => $vendorUser->id,
+        'status' => VendorStatusEnum::Approved->value,
+        'store_name' => 'Vendor',
+        'country_code' => 'RO',
+    ]);
+
+    $department = Department::create([
+        'name' => 'Dept',
+        'slug' => 'dept',
+    ]);
+
+    $category = Category::create([
+        'name' => 'Cat',
+        'department_id' => $department->id,
+        'active' => true,
+    ]);
+
+    $product = Product::create([
+        'title' => 'Prod',
+        'slug' => 'prod',
+        'description' => 'desc',
+        'department_id' => $department->id,
+        'category_id' => $category->id,
+        'price' => 100,
+        'status' => ProductStatusEnum::Published->value,
+        'quantity' => 10,
+        'created_by' => $vendorUser->id,
+        'updated_by' => $vendorUser->id,
+        'vat_rate_type' => 'standard_rate',
+    ]);
+
+    $found = Product::forWebsite()->first();
+
+    expect($found)->not->toBeNull();
+    expect($found->id)->toBe($product->id);
+});


### PR DESCRIPTION
## Summary
- keep product IDs intact by selecting only `products.*` in `vendorApproved` scope
- add regression test for `forWebsite` scope ensuring product IDs are correct

## Testing
- `./vendor/bin/pest tests/Feature/ProductForWebsiteScopeTest.php` *(fails: file not found)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a855f5646883238cb75e6e50af2b5e