### PR TITLE
Ensure product image fallback when option media missing

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -128,7 +128,7 @@ class Product extends Model implements HasMedia
             $options = VariationTypeOption::whereIn('id', $optionIds)->get();
             foreach ($options as $option) {
                 $images = $option->getMedia('images');
-                if ($images) {
+                if ($images->isNotEmpty()) {
                     return $images;
                 }
             }
@@ -163,7 +163,7 @@ class Product extends Model implements HasMedia
         if ($this->options->count() > 0) {
             foreach ($this->options as $option) {
                 $images = $option->getMedia('images');
-                if ($images) {
+                if ($images->isNotEmpty()) {
                     return $images;
                 }
             }

--- a/tests/Unit/ProductImageFallbackTest.php
+++ b/tests/Unit/ProductImageFallbackTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\Product;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+it('returns product images when options have none', function () {
+    $productImages = collect([Mockery::mock(Media::class)]);
+    $product = Mockery::mock(Product::class)->makePartial();
+    $product->shouldReceive('getMedia')->with('images')->andReturn($productImages);
+
+    $option = Mockery::mock();
+    $option->shouldReceive('getMedia')->with('images')->andReturn(collect());
+
+    $product->setRelation('options', collect([$option]));
+
+    $result = $product->getImages();
+
+    expect($result)->toBe($productImages);
+});
+
+it('returns product images for getImagesForOptions when options lack images', function () {
+    $productImages = collect([Mockery::mock(Media::class)]);
+    $product = Mockery::mock(Product::class)->makePartial();
+    $product->shouldReceive('getMedia')->with('images')->andReturn($productImages);
+
+    $option = Mockery::mock();
+    $option->shouldReceive('getMedia')->with('images')->andReturn(collect());
+
+    $alias = Mockery::mock('alias:App\\Models\\VariationTypeOption');
+    $alias->shouldReceive('whereIn')->with('id', [1])->andReturnSelf();
+    $alias->shouldReceive('get')->andReturn(collect([$option]));
+
+    $result = $product->getImagesForOptions([1]);
+
+    expect($result)->toBe($productImages);
+});


### PR DESCRIPTION
## Summary
- check option images with `isNotEmpty()` before returning
- add tests for product image fallback when option media is absent

## Testing
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a855f6695c83239058b479776ff80e