### PR TITLE
Handle unauthenticated vendor scope and add test

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -30,7 +30,13 @@ class Product extends Model implements HasMedia
 
     public function scopeForVendor(Builder $query): Builder
     {
-        return $query->where('created_by', auth()->user()->id);
+        $userId = auth()->id();
+
+        if ($userId === null) {
+            return $query;
+        }
+
+        return $query->where('created_by', $userId);
     }
 
     public function scopePublished(Builder $query): Builder

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use Illuminate\Foundation\Testing\Concerns\CreatesApplication;
 }

--- a/tests/Unit/ProductScopeTest.php
+++ b/tests/Unit/ProductScopeTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Models\Product;
+
+uses(Tests\TestCase::class);
+
+test('scopeForVendor does not alter the query when no user is authenticated', function () {
+    $baseSql = Product::query()->toSql();
+
+    $scopedSql = Product::query()->forVendor()->toSql();
+
+    expect($scopedSql)->toBe($baseSql);
+});
+


### PR DESCRIPTION
## Summary
- use `auth()->id()` in `Product::scopeForVendor` and ignore query when unauthenticated
- enable application bootstrap for tests
- add test covering unauthenticated vendor scope

## Testing
- `./vendor/bin/pest tests/Unit/ProductScopeTest.php` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a855f82dcc832391a312d0b1f094c3