### PR TITLE
Handle missing vendor when exposing store name

### DIFF
--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -40,7 +40,7 @@ class ProductResource extends JsonResource
             'user' => [
                 'id' => $this->user->id,
                 'name' => $this->user->name,
-                'store_name' => $this->user->vendor->store_name,
+                'store_name' => optional($this->user->vendor)->store_name ?? '',
             ],
             'department' => [
                 'id' => $this->department->id,


### PR DESCRIPTION
## Summary
- Guard against missing vendor when populating ProductResource user store name

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/marketplace/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a85ff723848323a1a847aa1f5ad992